### PR TITLE
[Realism] Add cloud shadows projection and vertex height displacement to Earth atmosphere

### DIFF
--- a/src/components/earth/CloudLayer.tsx
+++ b/src/components/earth/CloudLayer.tsx
@@ -6,15 +6,21 @@ import * as THREE from "three"
 import { createProceduralCloudTexture } from "./textures"
 
 const vertexShader = `
+uniform sampler2D cloudTexture;
 varying vec2 vUv;
 varying vec3 vNormal;
 varying vec3 vPosition;
+varying float vCloudDensity;
 
 void main() {
   vUv = uv;
   vNormal = normalize(normalMatrix * normal);
-  vPosition = (modelViewMatrix * vec4(position, 1.0)).xyz;
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  float cloudDensity = texture2D(cloudTexture, uv).r;
+  vCloudDensity = cloudDensity;
+  float displacement = cloudDensity * 0.018;
+  vec3 newPosition = position + normal * displacement;
+  vPosition = (modelViewMatrix * vec4(newPosition, 1.0)).xyz;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(newPosition, 1.0);
 }
 `
 
@@ -25,10 +31,11 @@ uniform vec3 sunDirection;
 varying vec2 vUv;
 varying vec3 vNormal;
 varying vec3 vPosition;
+varying float vCloudDensity;
 
 void main() {
   vec4 cloudColor = texture2D(cloudTexture, vUv);
-  float alpha = cloudColor.r * 0.6;
+  float alpha = cloudColor.r * 0.65;
 
   vec3 normal = normalize(vNormal);
   vec3 sunDir = normalize(sunDirection);
@@ -67,7 +74,7 @@ export function CloudLayer({ sunDirection }: CloudLayerProps) {
 
   return (
     <mesh ref={meshRef}>
-      <sphereGeometry args={[1.85, 32, 32]} />
+      <sphereGeometry args={[1.85, 48, 48]} />
       <shaderMaterial
         uniforms={uniformsRef.current}
         vertexShader={vertexShader}

--- a/src/components/earth/Earth.tsx
+++ b/src/components/earth/Earth.tsx
@@ -7,6 +7,7 @@ import {
   createProceduralEarthTexture,
   createProceduralNightTexture,
   createProceduralSpecularTexture,
+  createProceduralCloudTexture,
 } from "./textures"
 
 const vertexShader = `
@@ -26,6 +27,7 @@ const fragmentShader = `
 uniform sampler2D dayTexture;
 uniform sampler2D nightTexture;
 uniform sampler2D specularTexture;
+uniform sampler2D cloudShadowTexture;
 uniform vec3 sunDirection;
 
 varying vec2 vUv;
@@ -42,13 +44,19 @@ void main() {
   vec3 nightColor = texture2D(nightTexture, vUv).rgb;
   float specularMap = texture2D(specularTexture, vUv).r;
 
+  // Cloud shadow projected onto Earth surface
+  // Offset UV slightly in the sun direction to simulate shadow projection
+  vec2 shadowOffset = vec2(sunDir.x, sunDir.y) * 0.012;
+  float cloudShadow = texture2D(cloudShadowTexture, vUv + shadowOffset).r;
+  float shadowFactor = 1.0 - cloudShadow * 0.35 * step(0.0, NdotL);
+
   float dayMix = clamp(NdotL * 1.2 + 0.1, 0.0, 1.0);
 
   float twilight = 1.0 - abs(NdotL);
   twilight = smoothstep(0.0, 0.6, twilight);
   vec3 twilightColor = vec3(0.9, 0.4, 0.1) * twilight * 0.5;
 
-  vec3 color = mix(nightColor * vec3(0.15), dayColor, dayMix);
+  vec3 color = mix(nightColor * vec3(0.15), dayColor * shadowFactor, dayMix);
   color += twilightColor;
 
   vec3 viewDir = normalize(-vPosition);
@@ -83,6 +91,7 @@ export function Earth({ sunDirection }: EarthProps) {
     dayTexture: { value: makeDefaultTexture() as THREE.Texture },
     nightTexture: { value: makeDefaultTexture() as THREE.Texture },
     specularTexture: { value: makeDefaultTexture() as THREE.Texture },
+    cloudShadowTexture: { value: makeDefaultTexture() as THREE.Texture },
     sunDirection: { value: sunDirection.clone() },
   })
 
@@ -90,9 +99,11 @@ export function Earth({ sunDirection }: EarthProps) {
     const day = new THREE.CanvasTexture(createProceduralEarthTexture())
     const night = new THREE.CanvasTexture(createProceduralNightTexture())
     const spec = new THREE.CanvasTexture(createProceduralSpecularTexture())
+    const cloud = new THREE.CanvasTexture(createProceduralCloudTexture())
     uniformsRef.current.dayTexture.value = day
     uniformsRef.current.nightTexture.value = night
     uniformsRef.current.specularTexture.value = spec
+    uniformsRef.current.cloudShadowTexture.value = cloud
     // sunDirection is constant — set once
     uniformsRef.current.sunDirection.value.copy(sunDirection)
   }, [sunDirection])


### PR DESCRIPTION
## Summary

Adds subtle dark cloud shadows projected onto the Earth day texture based on the sun direction, and vertex shader displacement to make the cloud layer feel elevated and 3D.

## Changes

### \src/components/earth/CloudLayer.tsx\
- Vertex height displacement: cloud density sampled in vertex shader displaces vertices outward along normals by up to 0.018 units
- Increased geometry resolution: sphere segments 32 to 48 for smoother displacement
- Slightly increased cloud alpha from 0.6 to 0.65

### \src/components/earth/Earth.tsx\
- New cloudShadowTexture uniform generated from createProceduralCloudTexture
- Directional shadow projection with UV offset by sunDir.xy x 0.012
- Day-side darkening: day color multiplied by (1.0 - cloudShadow x 0.35)

Closes #3