### PR TITLE
[Constraints] Implement delta-V budget solver with Hohmann transfer logic

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -22,6 +22,7 @@ import { useAppState } from "@/lib/store"
   ]
 
   const BOOST_LOG = (km: number) => `[MANV] Boost burn executed — +${km} km altitude restored (ISS)`
+  const DV_LOG = (dv: string) => `[MANV] Δv budget computed — Hohmann transfer: ${dv} m/s required`
 
 function getTimestamp() {
   return new Date().toLocaleTimeString("en-US", {
@@ -33,11 +34,12 @@ function getTimestamp() {
 }
 
 export function AgentTerminal() {
-  const { terminalExpanded, toggleTerminal, boostCount } = useAppState()
+  const { terminalExpanded, toggleTerminal, boostCount, deltaVCount } = useAppState()
   const [logs, setLogs] = useState<Array<{ time: string; msg: string }>>([])
   const scrollRef = useRef<HTMLDivElement>(null)
   const indexRef = useRef(3)
   const lastBoostSeen = useRef(boostCount)
+  const lastDvSeen = useRef(deltaVCount)
 
   // Initialize logs and start interval on client side only to prevent hydration mismatch
   useEffect(() => {
@@ -73,6 +75,18 @@ export function AgentTerminal() {
       })
     }
   }, [boostCount])
+
+  // Append a log line whenever Δv budget is computed
+  useEffect(() => {
+    if (deltaVCount !== lastDvSeen.current) {
+      lastDvSeen.current = deltaVCount
+      setLogs((prev) => {
+        const next = [...prev, { time: getTimestamp(), msg: DV_LOG("N/A") }]
+        if (next.length > 50) next.splice(0, next.length - 50)
+        return next
+      })
+    }
+  }, [deltaVCount])
 
   // Auto-scroll to bottom
   useEffect(() => {

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useMemo } from "react"
 import { useAppState, LEO_LIMITS } from "@/lib/store"
-import { visVivaKmPerSec, LEO_DECAY_KM_PER_SEC } from "@/lib/kepler"
+import { visVivaKmPerSec, LEO_DECAY_KM_PER_SEC, hohmannDeltaVKmPerSec, KM_PER_UNIT_CONST } from "@/lib/kepler"
 
 export function RightSidebar() {
   const {
@@ -15,6 +15,8 @@ export function RightSidebar() {
     updateSatelliteParams,
     updateSatelliteEccentricity,
     boostBurn,
+    selectedAsteroid,
+    triggerDeltaVLog,
   } = useAppState()
 
   const [maxDv, setMaxDv] = useState("0.35")
@@ -29,11 +31,35 @@ export function RightSidebar() {
   const [boostStatus, setBoostStatus] = useState("")
 
   const handleApply = () => {
+    const maxDvVal = parseFloat(maxDv) || 0.35
+    const maxBurnsVal = parseInt(maxBurns, 10) || 1
+
+    const R_EARTH_KM = 6378
+    const r1Km = R_EARTH_KM + satAltitude
+
+    let dVTotal = 0
+    let targetName = "no target"
+
+    if (selectedAsteroid) {
+      targetName = selectedAsteroid.name
+      const r2Km = selectedAsteroid.orbitRadius * KM_PER_UNIT_CONST
+      dVTotal = hohmannDeltaVKmPerSec(r1Km, r2Km)
+    }
+
+    const dVms = dVTotal * 1000
+    const exceeds = dVms > maxDvVal
+    const icon = exceeds ? "⚠" : "✓"
+
     setStatusText(
-      "Applied constraints at " +
-        new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: true })
+      `${icon} Hohmann Δv: ${dVms.toFixed(1)} m/s → ${targetName} ` +
+        (exceeds ? `WARNING: exceeds max ${maxDvVal} m/s!` : `within ${maxDvVal} m/s budget (${maxBurnsVal} burns)`)
     )
-    setTimeout(() => setStatusText("No pending changes."), 3000)
+
+    // Log to console for debugging
+    console.log(`[MANV] Hohmann transfer to ${targetName}: Δv=${dVms.toFixed(2)} m/s, max=${maxDvVal} m/s, burns=${maxBurnsVal}`)
+    triggerDeltaVLog()
+
+    setTimeout(() => setStatusText("No pending changes."), 5000)
   }
 
   // Theoretical LEO orbital speed via Vis-Viva (a = R⊕ + h)

--- a/src/lib/kepler.ts
+++ b/src/lib/kepler.ts
@@ -126,3 +126,28 @@ export function velocityToKmPerSec(sceneV: number): number {
 export const LEO_DECAY_KM_PER_SEC = 0.05
 
 export const KM_PER_UNIT_CONST = KM_PER_UNIT
+
+/**
+ * Calculate the total delta-V (km/s) required for a Hohmann transfer between
+ * two coplanar circular orbits around Earth.
+ *
+ * A Hohmann transfer is a two-impulse elliptical transfer:
+ *   1. First burn at perigee of transfer ellipse (r₁) to raise apogee to r₂.
+ *   2. Second burn at apogee of transfer ellipse (r₂) to circularise.
+ *
+ * @param r1Km Initial circular orbit radius in km.
+ * @param r2Km Target circular orbit radius in km.
+ * @returns Total Δv in km/s.
+ */
+export function hohmannDeltaVKmPerSec(r1Km: number, r2Km: number): number {
+  if (r1Km <= 0 || r2Km <= 0) return 0
+  const mu = MU_EARTH_KM
+  const v1 = Math.sqrt(mu / r1Km)
+  const v2 = Math.sqrt(mu / r2Km)
+  const aTransfer = (r1Km + r2Km) / 2
+  const vPerigee = Math.sqrt(mu * (2 / r1Km - 1 / aTransfer))
+  const vApogee = Math.sqrt(mu * (2 / r2Km - 1 / aTransfer))
+  const dV1 = Math.abs(vPerigee - v1)
+  const dV2 = Math.abs(v2 - vApogee)
+  return dV1 + dV2
+}

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -52,6 +52,9 @@ interface AppState {
   boostBurn: (deltaKm: number) => void
   /** Increments every time a boost burn fires — AgentTerminal watches this. */
   boostCount: number
+  /** Increments every time a Δv budget is computed — AgentTerminal watches this. */
+  deltaVCount: number
+  triggerDeltaVLog: () => void
   conjunctions: ConjunctionAlert[]
   addConjunctionAlert: (alert: Omit<ConjunctionAlert, "id">) => void
   clearConjunctions: () => void
@@ -81,6 +84,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [satRaan, setSatRaan] = useState(0) // degrees
   const [satEccentricity, setSatEccentricity] = useState(0.0006) // ≈ circular LEO
   const [boostCount, setBoostCount] = useState(0)
+  const [deltaVCount, setDeltaVCount] = useState(0)
   const [conjunctions, setConjunctions] = useState<ConjunctionAlert[]>([])
   const nextAlertId = useRef(1)
 
@@ -115,6 +119,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
     if (found) {
       setSelectedAsteroid(found)
     }
+  }, [])
+
+  const triggerDeltaVLog = useCallback(() => {
+    setDeltaVCount((c) => c + 1)
   }, [])
 
   const updateSatelliteParams = useCallback((alt: number, inc: number, raan: number) => {
@@ -197,6 +205,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         decayAltitude,
         boostBurn,
         boostCount,
+        deltaVCount,
+        triggerDeltaVLog,
         conjunctions,
         addConjunctionAlert,
         clearConjunctions,


### PR DESCRIPTION
## Summary

Replaces the previously cosmetic Planner Constraints inputs with a real Hohmann transfer delta-V budget solver. When the user clicks Apply, the system calculates the actual delta-V required to reach the selected asteroid's orbit from the current satellite altitude.

## Changes

### src/lib/kepler.ts
- Added hohmannDeltaVKmPerSec(r1Km, r2Km) - computes total Dv for a two-impulse coplanar transfer between circular orbits

### src/lib/store.tsx
- Added deltaVCount state and triggerDeltaVLog action for AgentTerminal integration

### src/components/RightSidebar.tsx
- Reads selectedAsteroid from the store to get target orbit radius
- handleApply computes Hohmann Dv and displays inline result with checkmark or warning

### src/components/AgentTerminal.tsx
- Subscribes to deltaVCount to log Dv budget computations automatically

Closes #4