### PR TITLE
feat: add risk-level filter to Conjunction Alerter (#1)

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -15,6 +15,12 @@ export function LeftSidebar() {
     addConjunctionAlert,
   } = useAppState()
   const [searchId, setSearchId] = useState("")
+  const [riskFilter, setRiskFilter] = useState<"ALL" | "HIGH" | "MEDIUM" | "LOW">("ALL") 
+
+  const filteredConjunctions = useMemo(() => {
+  if (riskFilter === "ALL") return conjunctions
+  return conjunctions.filter((c) => c.risk === riskFilter)
+  }, [conjunctions, riskFilter])
 
   // Pre-seed some conjunctions at start if empty
   useEffect(() => {
@@ -219,12 +225,41 @@ export function LeftSidebar() {
 
             {/* Conjunction Feed */}
             <div className="panel-section" style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
                 <div className="panel-section-title" style={{ marginBottom: 0 }}>Conjunction Alerter</div>
-                <div style={{ fontSize: 9, color: "var(--text-muted)", fontFamily: "var(--font-mono), monospace" }}>
-                  {conjunctions.length} Active alerts
-                </div>
-              </div>
+                  <div
+                    style={{ fontSize: 9, color: "var(--text-muted)", fontFamily: "var(--font-mono), monospace" }}
+                    title={riskFilter !== "ALL" ? `${filteredConjunctions.length} of ${conjunctions.length} total` : undefined}
+                  >
+                   {filteredConjunctions.length} Active alerts
+                 </div>
+            </div>
+
+            {/* Risk filter — mirrors the Filter Catalog tab pattern */}
+            <div style={{ display: "flex", background: "var(--bg-input)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-sm)", padding: 2, marginBottom: 8 }}>
+              {(["ALL", "HIGH", "MEDIUM", "LOW"] as const).map((level) => (
+                <button
+                  key={level}
+                  onClick={() => setRiskFilter(level)}
+                  style={{
+                    flex: 1,
+                    padding: "5px 0",
+                    fontSize: 9,
+                    fontWeight: 700,
+                    letterSpacing: "0.04em",
+                    borderRadius: 4,
+                    background: riskFilter === level ? "rgba(56, 189, 248, 0.15)" : "transparent",
+                    border: riskFilter === level ? "1px solid rgba(56, 189, 248, 0.25)" : "1px solid transparent",
+                    color: riskFilter === level ? "var(--accent-cyan)" : "var(--text-secondary)",
+                    cursor: "pointer",
+                    transition: "all 0.2s ease",
+                  }}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
+
               <div style={{ flex: 1, overflowY: "auto" }}>
                 <table className="data-table">
                   <thead>
@@ -235,7 +270,7 @@ export function LeftSidebar() {
                     </tr>
                   </thead>
                   <tbody>
-                    {conjunctions.map((c) => (
+                    {filteredConjunctions.map((c) => (
                       <tr key={c.id}>
                         <td>
                           <div style={{ fontWeight: 600, color: "var(--text-primary)" }}>{c.satelliteName}</div>


### PR DESCRIPTION
Closes #1

## What's changed
Added a segmented filter control (ALL / HIGH / MEDIUM / LOW) above the Conjunction 
Alerter table in `LeftSidebar.tsx` that filters alerts by risk level in real-time.

## Changes made
- Added `riskFilter` local state (`useState`)
- Added `filteredConjunctions` via `useMemo` that filters the conjunction feed by 
  selected risk level
- Added a 4-tab segmented control styled to match the existing Filter Catalog tabs
- Alert counter reflects the filtered count with a tooltip showing "X of Y total" 
  when a filter is active
- Table rows now render from `filteredConjunctions` instead of `conjunctions`

## Files changed
- `src/components/LeftSidebar.tsx` only

## Before
<img width="436" height="927" alt="image" src="https://github.com/user-attachments/assets/47b6c712-1ba4-4d3e-990e-550acbc61b91" />

## After
<img width="438" height="940" alt="image" src="https://github.com/user-attachments/assets/56467e67-709e-4de4-b50b-738272963ed1" />

<img width="421" height="951" alt="image" src="https://github.com/user-attachments/assets/4f9b8998-614d-43f7-bf67-16813dbc3cad" />

<img width="405" height="946" alt="image" src="https://github.com/user-attachments/assets/4f668b00-fdcb-4fba-9d5e-3bcd748a1b56" />

<img width="414" height="944" alt="image" src="https://github.com/user-attachments/assets/0fc97828-281e-4c5d-986d-c18d2dcd4fde" />

## Notes
- No new dependencies added
- `npm run build` passes successfully
- `npm run lint` reports 16 pre-existing errors across other files , none related 
  to this PR
- kept consistent with the current type system