### PR TITLE
fix: declare postprocessing runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-three/fiber": "^9.6.1",
         "@react-three/postprocessing": "^3.0.4",
         "next": "16.2.7",
+        "postprocessing": "^6.39.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "three": "^0.184.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "next": "16.2.7",
+    "postprocessing": "^6.39.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "three": "^0.184.0"


### PR DESCRIPTION
Fixes #3.

## What changed

- Added `postprocessing` as a direct runtime dependency.
- Updated the root package-lock metadata so clean installs include the package used by `src/components/Effects.tsx`.

`BlendFunction` is imported directly from `postprocessing`, and `@react-three/postprocessing` does not re-export it. Declaring the direct dependency avoids relying on transitive dependency hoisting.

## Validation

- `node -e "const pkg=require('./package.json'); const lock=require('./package-lock.json'); ..."` confirmed `postprocessing` is declared in package.json and the lockfile root dependencies.
- `node -e "import('postprocessing').then(m=>console.log(typeof m.BlendFunction, m.BlendFunction.NORMAL))"` confirmed the imported symbol exists.
- `npx tsc --noEmit`
- `npm run build`

Note: `npm run lint` still reports pre-existing unrelated React hook/type lint errors in other files; this change only touches package dependency metadata.