### PR TITLE
fix: smooth Earth rotation and satellite orbits by fixing mean anomal…

### DIFF
--- a/src/components/AsteroidField.tsx
+++ b/src/components/AsteroidField.tsx
@@ -128,7 +128,7 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
     updateColors(debrisMeshRef.current, ASTEROID_COUNT, DEBRIS_COUNT, DEBRIS_COLORS)
   }, [])
 
-  useFrame((state, delta) => {
+  useFrame((state) => {
     const asteroidMesh = asteroidMeshRef.current
     const debrisMesh = debrisMeshRef.current
     if (!asteroidMesh || !debrisMesh) return
@@ -136,8 +136,6 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
     const selectedIdx = getSelectedIndex()
     const t = state.clock.getElapsedTime()
     const prevAtRisk = prevAtRiskRef.current
-    const deltaScaled = delta * SCENE_TIME_SCALE
-
     for (let i = 0; i < TOTAL_COUNT; i++) {
       const ad = dataRef.current[i]
       const isDebris = ad.type === "debris"
@@ -146,7 +144,7 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
       // 1. Keplerian propagation: M = n·t + M0  →  solve Kepler for E
       if (selectedIdx !== i && simulationRunning) {
         const n = meanMotion(ad.orbitRadius)
-        anglesRef.current[i] = solveKepler(n * t * deltaScaled + ad.meanAnomaly0, ad.eccentricity)
+        anglesRef.current[i] = solveKepler(n * t * SCENE_TIME_SCALE + ad.meanAnomaly0, ad.eccentricity)
       }
 
       const E = anglesRef.current[i]

--- a/src/components/SatelliteSystem.tsx
+++ b/src/components/SatelliteSystem.tsx
@@ -108,11 +108,13 @@ export function SatelliteSystem() {
   const envisatOrbitGeo = useMemo(() => createOrbitGeometry(envisatRadius, 0.0006, 98.54, 120), [envisatRadius])
   const hubbleOrbitGeo = useMemo(() => createOrbitGeometry(hubbleRadius, 0.0003, 28.5, 45), [hubbleRadius])
 
+  const _tempPos = useRef(new THREE.Vector3()).current
+
   useFrame((state, delta) => {
     if (!simulationRunning) return
 
     const time = state.clock.getElapsedTime()
-    const tempPos = new THREE.Vector3()
+    const tempPos = _tempPos
 
     // LEO atmospheric drag — slowly drop the ISS altitude in real time
     decayAltitude(LEO_DECAY_KM_PER_SEC * delta)


### PR DESCRIPTION
…y accumulation and per-frame Vector3 allocation

## 🔗 Related Issue
Closes #22 

---

## 📝 Description of Changes
<## What this PR fixes

Resolves #22 — Earth rotation stutter and incorrect satellite orbit animation.

## Root Causes Found

**1. Wrong mean anomaly formula in `AsteroidField.tsx`**
The orbital angle was computed as `n * t * delta * SCENE_TIME_SCALE` — 
multiplying absolute elapsed time `t` by per-frame `delta` caused the 
angle to grow non-linearly (as t²), making orbits stutter and drift 
depending on frame rate. Fixed to `n * t * SCENE_TIME_SCALE`.

**2. Per-frame `Vector3` allocation in `SatelliteSystem.tsx`**
`new THREE.Vector3()` was created inside `useFrame` on every frame 
(60×/sec), causing garbage collection pressure and frame drops. 
Replaced with a stable `useRef`-hoisted instance reused each frame.

## Core Files Changed

- `src/components/AsteroidField.tsx` — Fixed mean anomaly to use absolute time only
- `src/components/SatelliteSystem.tsx` — Hoisted scratch Vector3 out of the render loop

## Checklist

- [x] `npm run lint` — no new errors
- [x] `npm run build` — builds successfully ✓ (compiled in 5.7s)
- [x] `npx tsc --noEmit` — no type errors

Closes #22
>

---
## 🏷️ Proposed Labels
- [ ] UI/UX
- [ ] Documentation
- [ ] CI/CD
- [ ] Backend Logic
- [ ] Anything else

---
## 📂 Core Files Changed
<## What this PR fixes

Resolves #22 — Earth rotation stutter and incorrect satellite orbit animation.

## Root Causes Found

**1. Wrong mean anomaly formula in `AsteroidField.tsx`**
The orbital angle was computed as `n * t * delta * SCENE_TIME_SCALE` — 
multiplying absolute elapsed time `t` by per-frame `delta` caused the 
angle to grow non-linearly (as t²), making orbits stutter and drift 
depending on frame rate. Fixed to `n * t * SCENE_TIME_SCALE`.

**2. Per-frame `Vector3` allocation in `SatelliteSystem.tsx`**
`new THREE.Vector3()` was created inside `useFrame` on every frame 
(60×/sec), causing garbage collection pressure and frame drops. 
Replaced with a stable `useRef`-hoisted instance reused each frame.

## Core Files Changed

- `src/components/AsteroidField.tsx` — Fixed mean anomaly to use absolute time only
- `src/components/SatelliteSystem.tsx` — Hoisted scratch Vector3 out of the render loop

## Checklist

- [x] `npm run lint` — no new errors
- [x] `npm run build` — builds successfully ✓ (compiled in 5.7s)
- [x] `npx tsc --noEmit` — no type errors

Closes #22
>

---
## 📸 Verification & Screenshots
- **UI/UX (User Interface / User Experience - how it looks and feels):**
  
- **CI/CD (Continuous Integration / Continuous Deployment - the automated build/test pipeline):**

---
## 🤖 AI Assistance Declaration
**Did you use an AI tool to write or assist with this code OR Pull Request?**
- [ ] Yes
- [ ] No (If no, you can skip the rest of this section)

> **⚠️ IF YOU CHECKED "YES", YOU MUST ANSWER THE FOLLOWING:**
* **Which AI Model did you use?** *(e.g., GPT-4o, Claude 4.5 Sonnet)*: 
* **Which Platform/Tool?** *(e.g., Cursor, OpenCode, Codex, Claude Code, GitHub Copilot, standard web chat)*: 
* **What exactly did the AI do?**: 
* **What exactly did YOU do?**: 
* **What is the advantage of using this AI approach here?**:
  
---

## ⚠️ Reviewer Notes
<--Write anything important (other than the above) that I should know-->

---

## ✅ The "I Swear I Didn't Break Anything" Pledge
- [ ] I have thoroughly tested these changes in my own local branch.
- [ ] I verified multiple times that this code compiles into a standalone build and does not break existing production features.
