### PR TITLE
Fix boost speed unit display

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -86,7 +86,7 @@ export function RightSidebar() {
   const handleBoost = () => {
     const burnKm = 50
     boostBurn(burnKm)
-    setBoostStatus(`Boost burn executed: +${burnKm} km @ ${displaySpeedKmS.toFixed(0)} m/s Δv`)
+    setBoostStatus(`Boost burn executed: +${burnKm} km @ ${displaySpeedKmS.toFixed(2)} km/s`)
     setTimeout(() => setBoostStatus(""), 3000)
   }
 


### PR DESCRIPTION
## Summary
- display boost-burn speed in km/s to match the value returned by Vis-Viva telemetry
- avoid showing kilometer-per-second orbital speed as meters per second

## Verification
- npm run build