### PR TITLE
Initialize terminal logs without effect state cascade

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -33,22 +33,21 @@ function getTimestamp() {
   })
 }
 
+function createInitialLogs() {
+  return [
+    { time: getTimestamp(), msg: LOG_MESSAGES[0] },
+    { time: getTimestamp(), msg: LOG_MESSAGES[1] },
+    { time: getTimestamp(), msg: LOG_MESSAGES[2] },
+  ]
+}
+
 export function AgentTerminal() {
   const { terminalExpanded, toggleTerminal, boostCount, deltaVCount } = useAppState()
-  const [logs, setLogs] = useState<Array<{ time: string; msg: string }>>([])
+  const [logs, setLogs] = useState(createInitialLogs)
   const scrollRef = useRef<HTMLDivElement>(null)
   const indexRef = useRef(3)
   const lastBoostSeen = useRef(boostCount)
   const lastDvSeen = useRef(deltaVCount)
-
-  // Initialize logs and start interval on client side only to prevent hydration mismatch
-  useEffect(() => {
-    setLogs([
-      { time: getTimestamp(), msg: LOG_MESSAGES[0] },
-      { time: getTimestamp(), msg: LOG_MESSAGES[1] },
-      { time: getTimestamp(), msg: LOG_MESSAGES[2] },
-    ])
-  }, [])
 
   // Auto-generate log entries
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize terminal log state with a lazy state initializer
- remove synchronous setState from the mount effect flagged by React hooks linting

## Verification
- npm run build