### PR TITLE
Avoid Earth shader uniform ref reads during render

### DIFF
--- a/src/components/earth/Earth.tsx
+++ b/src/components/earth/Earth.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useEffect } from "react"
+import { useRef, useEffect, useMemo } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 import {
@@ -88,26 +88,26 @@ function makeDefaultTexture() {
 export function Earth({ sunDirection }: EarthProps) {
   const meshRef = useRef<THREE.Mesh>(null)
 
-  const uniformsRef = useRef({
+  const uniforms = useMemo(() => ({
     dayTexture: { value: makeDefaultTexture() as THREE.Texture },
     nightTexture: { value: makeDefaultTexture() as THREE.Texture },
     specularTexture: { value: makeDefaultTexture() as THREE.Texture },
     cloudShadowTexture: { value: makeDefaultTexture() as THREE.Texture },
     sunDirection: { value: sunDirection.clone() },
-  })
+  }), [sunDirection])
 
   useEffect(() => {
     const day = new THREE.CanvasTexture(createProceduralEarthTexture())
     const night = new THREE.CanvasTexture(createProceduralNightTexture())
     const spec = new THREE.CanvasTexture(createProceduralSpecularTexture())
     const cloud = new THREE.CanvasTexture(createProceduralCloudTexture())
-    uniformsRef.current.dayTexture.value = day
-    uniformsRef.current.nightTexture.value = night
-    uniformsRef.current.specularTexture.value = spec
-    uniformsRef.current.cloudShadowTexture.value = cloud
+    uniforms.dayTexture.value = day
+    uniforms.nightTexture.value = night
+    uniforms.specularTexture.value = spec
+    uniforms.cloudShadowTexture.value = cloud
     // sunDirection is constant — set once
-    uniformsRef.current.sunDirection.value.copy(sunDirection)
-  }, [sunDirection])
+    uniforms.sunDirection.value.copy(sunDirection)
+  }, [sunDirection, uniforms])
 
   useFrame((_, delta) => {
     if (meshRef.current) {
@@ -119,7 +119,7 @@ export function Earth({ sunDirection }: EarthProps) {
     <mesh ref={meshRef}>
       <sphereGeometry args={[1.8, 64, 64]} />
       <shaderMaterial
-        uniforms={uniformsRef.current}
+        uniforms={uniforms}
         vertexShader={vertexShader}
         fragmentShader={fragmentShader}
       />


### PR DESCRIPTION
## Summary
- replace Earth shader uniform ref reads in JSX with a memoized uniforms object
- keep procedural texture assignment in the effect while satisfying React ref rules

## Verification
- npm run build