### PR TITLE
fix: improve terminal notification accessibility

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -3,6 +3,11 @@
 import { useState, useEffect, useRef } from "react"
 import { useAppState } from "@/lib/store"
 
+type LogEntry = {
+  time: string
+  msg: string
+}
+
   const LOG_MESSAGES = [
     "[SYS] Orbital propagator initialized — 600 objects tracked",
     "[CONJ] Scanning primary object catalog for close approaches...",
@@ -43,7 +48,7 @@ function createInitialLogs() {
 
 export function AgentTerminal() {
   const { terminalExpanded, toggleTerminal, boostCount, deltaVCount } = useAppState()
-  const [logs, setLogs] = useState(createInitialLogs)
+  const [logs, setLogs] = useState<LogEntry[]>(createInitialLogs)
   const scrollRef = useRef<HTMLDivElement>(null)
   const indexRef = useRef(3)
   const lastBoostSeen = useRef(boostCount)
@@ -117,6 +122,9 @@ export function AgentTerminal() {
       {/* Toggle bar */}
       <button
         onClick={toggleTerminal}
+        aria-controls="agent-terminal-log"
+        aria-expanded={terminalExpanded}
+        aria-label={terminalExpanded ? "Collapse agent terminal notifications" : "Expand agent terminal notifications"}
         style={{
           display: "flex",
           alignItems: "center",
@@ -167,7 +175,12 @@ export function AgentTerminal() {
       {/* Terminal content */}
       {terminalExpanded && (
         <div
+          id="agent-terminal-log"
           ref={scrollRef}
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions text"
+          aria-label="Agent terminal notifications"
           style={{
             flex: 1,
             overflowY: "auto",


### PR DESCRIPTION
## Summary
- add explicit live-region semantics to the Agent Terminal notification log
- expose the terminal toggle state with `aria-expanded` and a descriptive label
- type terminal log entries for clearer maintainability while preserving current UI behavior

## Validation
- `git diff --check`
- `npm.cmd install --ignore-scripts` *(blocked locally: ENOSPC/no space left on device while installing dependencies)*

Fixes #529
