### PR TITLE
feat: add contributor issue management automation

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,20 +11,190 @@ permissions:
 
 jobs:
   assign:
+    name: Handle assignment commands
     if: github.event.issue.pull_request == null
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - name: Assign issue from comment command
+        uses: actions/github-script@v7
         with:
-          node-version: 20
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const body = (comment.body || "").trim();
+            const MAX_ACTIVE_ASSIGNMENTS = 3;
+            const MAINTAINER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
-      - run: npm install @actions/github @actions/core
+            if (issue.pull_request) {
+              core.info("Ignoring pull request comments.");
+              return;
+            }
 
-      - run: node .github/scripts/autoAssign.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+            if (comment.user.type === "Bot") {
+              core.info(`Ignoring bot comment from ${comment.user.login}.`);
+              return;
+            }
+
+            const forceAssignMatch = body.match(/^\/force-assign\s+@?([A-Za-z0-9-]+)\s*$/);
+            const isAssignCommand = body === "/assign";
+
+            if (!isAssignCommand && !forceAssignMatch) {
+              core.info("Comment does not contain a supported assignment command.");
+              return;
+            }
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  core.warning(`Could not read label "${name}": ${error.message}`);
+                  return;
+                }
+
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                  core.info(`Created missing label "${name}".`);
+                } catch (createError) {
+                  if (createError.status === 422) {
+                    core.info(`Label "${name}" already exists.`);
+                  } else {
+                    core.warning(`Could not create label "${name}": ${createError.message}`);
+                  }
+                }
+              }
+            }
+
+            async function hasExistingBotComment(text) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              return comments.some((existingComment) => {
+                return existingComment.user?.type === "Bot" && existingComment.body?.includes(text);
+              });
+            }
+
+            async function createCommentOnce(body, duplicateText = body) {
+              if (await hasExistingBotComment(duplicateText)) {
+                core.info(`Skipping duplicate comment: ${duplicateText}`);
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body,
+              });
+            }
+
+            async function getPermission(login) {
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: login,
+                });
+                return response.data.permission;
+              } catch (error) {
+                if (error.status === 404) {
+                  return "none";
+                }
+                core.warning(`Could not determine permission for ${login}: ${error.message}`);
+                return "none";
+              }
+            }
+
+            async function countOpenAssignedIssues(login) {
+              const assignedItems = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: "open",
+                assignee: login,
+                per_page: 100,
+              });
+
+              return assignedItems.filter((item) => !item.pull_request).length;
+            }
+
+            async function assignUser(login) {
+              await ensureLabel("waiting-for-pr", "FBCA04", "Assigned issue waiting for a linked pull request.");
+              await ensureLabel("stale-assignment", "B60205", "Assignment expired because no linked pull request was opened in time.");
+
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees: [login],
+              });
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  labels: ["waiting-for-pr"],
+                });
+              } catch (error) {
+                core.warning(`Issue was assigned, but adding waiting-for-pr failed: ${error.message}`);
+              }
+            }
+
+            if (forceAssignMatch) {
+              const actor = comment.user.login;
+              const target = forceAssignMatch[1];
+              const permission = await getPermission(actor);
+
+              if (!MAINTAINER_PERMISSIONS.has(permission)) {
+                await createCommentOnce("Only maintainers can use this command.", "Only maintainers can use this command.");
+                return;
+              }
+
+              if (issue.assignees.some((assignee) => assignee.login.toLowerCase() === target.toLowerCase())) {
+                await createCommentOnce(`✅ Assigned to @${target}.`, `Assigned to @${target}`);
+                return;
+              }
+
+              try {
+                await assignUser(target);
+                await createCommentOnce(`✅ Assigned to @${target}.`, `Assigned to @${target}`);
+              } catch (error) {
+                core.setFailed(`Failed to force-assign @${target}: ${error.message}`);
+              }
+              return;
+            }
+
+            if (issue.assignees.length > 0) {
+              await createCommentOnce("This issue has already been assigned.", "This issue has already been assigned.");
+              return;
+            }
+
+            const actor = comment.user.login;
+            const activeAssignments = await countOpenAssignedIssues(actor);
+
+            if (activeAssignments >= MAX_ACTIVE_ASSIGNMENTS) {
+              await createCommentOnce(
+                "❌ You already have the maximum limit of 3 active assigned issues. Complete one before claiming another.",
+                "maximum limit of 3 active assigned issues"
+              );
+              return;
+            }
+
+            try {
+              await assignUser(actor);
+            } catch (error) {
+              core.setFailed(`Failed to assign @${actor}: ${error.message}`);
+              return;
+            }
+
+            const newAssignmentCount = activeAssignments + 1;
+            await createCommentOnce(
+              `✅ Assigned to @${actor}.\n\nYou currently have ${newAssignmentCount}/3 active assignments.\n\nPlease open a linked pull request within **5 days**, otherwise the assignment will be removed automatically.`,
+              `Assigned to @${actor}`
+            );

--- a/.github/workflows/issue-limit.yml
+++ b/.github/workflows/issue-limit.yml
@@ -2,7 +2,7 @@ name: Issue Limit
 
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   issues: write
@@ -10,19 +10,96 @@ permissions:
 
 jobs:
   limit:
+    name: Enforce open issue limit
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - name: Close issues above contributor limit
+        uses: actions/github-script@v7
         with:
-          node-version: 20
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const actor = issue.user.login;
+            const MAX_OPEN_ISSUES = 5;
+            const MAINTAINER_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
-      - run: npm install @actions/github @actions/core
+            if (issue.pull_request) {
+              core.info("Ignoring pull request event.");
+              return;
+            }
 
-      - run: node .github/scripts/issueLimit.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+            if (issue.user.type === "Bot") {
+              core.info(`Ignoring bot-created issue from ${actor}.`);
+              return;
+            }
+
+            async function getPermission(login) {
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: login,
+                });
+                return response.data.permission;
+              } catch (error) {
+                if (error.status === 404) {
+                  return "none";
+                }
+                core.warning(`Could not determine permission for ${login}: ${error.message}`);
+                return "none";
+              }
+            }
+
+            const permission = await getPermission(actor);
+            if (MAINTAINER_PERMISSIONS.has(permission)) {
+              core.info(`${actor} has ${permission} permission and bypasses issue limits.`);
+              return;
+            }
+
+            const authoredItems = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              creator: actor,
+              per_page: 100,
+            });
+
+            const openIssueCount = authoredItems.filter((item) => !item.pull_request).length;
+            core.info(`${actor} currently has ${openIssueCount} open issue(s).`);
+
+            if (openIssueCount <= MAX_OPEN_ISSUES) {
+              return;
+            }
+
+            const limitComment = "You already have 5 open issues.\n\nPlease wait until one is resolved before opening another.";
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+
+            const alreadyCommented = comments.some((comment) => {
+              return comment.user?.type === "Bot" && comment.body?.includes("You already have 5 open issues.");
+            });
+
+            if (!alreadyCommented) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: limitComment,
+              });
+            }
+
+            if (issue.state !== "closed") {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: "closed",
+                state_reason: "not_planned",
+              });
+            }

--- a/.github/workflows/stale-assignment.yml
+++ b/.github/workflows/stale-assignment.yml
@@ -3,7 +3,6 @@ name: Remove Stale Assignments
 on:
   schedule:
     - cron: "0 0 * * *"
-
   workflow_dispatch:
 
 permissions:
@@ -13,18 +12,363 @@ permissions:
 
 jobs:
   stale:
+    name: Expire inactive assignments
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - name: Remove assignments without linked pull requests
+        uses: actions/github-script@v7
         with:
-          node-version: 20
+          script: |
+            const { owner, repo } = context.repo;
+            const ASSIGNMENT_WINDOW_DAYS = 5;
+            const ASSIGNMENT_WINDOW_MS = ASSIGNMENT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const pullRequestCache = new Map();
 
-      - run: npm install @actions/github @actions/core
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  core.warning(`Could not read label "${name}": ${error.message}`);
+                  return;
+                }
 
-      - run: node .github/scripts/staleAssignment.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                  core.info(`Created missing label "${name}".`);
+                } catch (createError) {
+                  if (createError.status === 422) {
+                    core.info(`Label "${name}" already exists.`);
+                  } else {
+                    core.warning(`Could not create label "${name}": ${createError.message}`);
+                  }
+                }
+              }
+            }
+
+            async function listTimeline(issueNumber) {
+              return github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+            }
+
+            function currentAssigneeLogins(issue) {
+              return new Set(issue.assignees.map((assignee) => assignee.login));
+            }
+
+            function latestAssignmentDates(issue, timelineEvents) {
+              const currentAssignees = currentAssigneeLogins(issue);
+              const datesByLogin = new Map();
+
+              for (const assignee of currentAssignees) {
+                datesByLogin.set(assignee, null);
+              }
+
+              for (const event of timelineEvents) {
+                const assignee = event.assignee?.login;
+                if (!assignee || !currentAssignees.has(assignee)) {
+                  continue;
+                }
+
+                if (event.event === "assigned") {
+                  datesByLogin.set(assignee, new Date(event.created_at));
+                }
+
+                if (event.event === "unassigned") {
+                  datesByLogin.set(assignee, null);
+                }
+              }
+
+              for (const [login, assignedAt] of datesByLogin) {
+                if (!assignedAt) {
+                  core.warning(`No assignment event found for @${login} on #${issue.number}; using issue creation time as a conservative fallback.`);
+                  datesByLogin.set(login, new Date(issue.created_at));
+                }
+              }
+
+              return datesByLogin;
+            }
+
+            function extractPullRequestNumber(event) {
+              const linkedIssue = event.source?.issue || event.source?.pull_request || event.subject?.issue;
+              if (linkedIssue?.pull_request && linkedIssue.number) {
+                return linkedIssue.number;
+              }
+
+              if (event.source?.type === "pull_request" && event.source?.issue?.number) {
+                return event.source.issue.number;
+              }
+
+              return null;
+            }
+
+            async function isActiveOrMergedPullRequest(number) {
+              if (pullRequestCache.has(number)) {
+                return pullRequestCache.get(number);
+              }
+
+              try {
+                const response = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: number,
+                });
+
+                const pull = response.data;
+                const isActive = pull.state === "open" || pull.merged === true;
+                pullRequestCache.set(number, isActive);
+                return isActive;
+              } catch (error) {
+                core.warning(`Could not inspect pull request #${number}: ${error.message}`);
+                pullRequestCache.set(number, false);
+                return false;
+              }
+            }
+
+            async function hasGraphqlLinkedPullRequest(issueNumber) {
+              const linkedPullRequests = new Map();
+              let cursor = null;
+
+              const query = `
+                query LinkedPullRequests($owner: String!, $repo: String!, $issueNumber: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $issueNumber) {
+                      timelineItems(first: 100, after: $cursor, itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT, CROSS_REFERENCED_EVENT]) {
+                        nodes {
+                          __typename
+                          ... on ConnectedEvent {
+                            subject {
+                              __typename
+                              ... on PullRequest {
+                                number
+                                state
+                              }
+                            }
+                          }
+                          ... on DisconnectedEvent {
+                            subject {
+                              __typename
+                              ... on PullRequest {
+                                number
+                                state
+                              }
+                            }
+                          }
+                          ... on CrossReferencedEvent {
+                            source {
+                              __typename
+                              ... on PullRequest {
+                                number
+                                state
+                              }
+                            }
+                          }
+                        }
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              do {
+                const response = await github.graphql(query, {
+                  owner,
+                  repo,
+                  issueNumber,
+                  cursor,
+                });
+
+                const timelineItems = response.repository.issue.timelineItems;
+                for (const node of timelineItems.nodes) {
+                  if (node.__typename === "ConnectedEvent" && node.subject?.__typename === "PullRequest") {
+                    linkedPullRequests.set(node.subject.number, node.subject.state);
+                  }
+
+                  if (node.__typename === "DisconnectedEvent" && node.subject?.__typename === "PullRequest") {
+                    linkedPullRequests.delete(node.subject.number);
+                  }
+
+                  if (node.__typename === "CrossReferencedEvent" && node.source?.__typename === "PullRequest") {
+                    linkedPullRequests.set(node.source.number, node.source.state);
+                  }
+                }
+
+                cursor = timelineItems.pageInfo.hasNextPage ? timelineItems.pageInfo.endCursor : null;
+              } while (cursor);
+
+              for (const [pullRequestNumber, state] of linkedPullRequests) {
+                if (state === "OPEN" || state === "MERGED") {
+                  core.info(`#${issueNumber} is protected by GraphQL-linked pull request #${pullRequestNumber}.`);
+                  return true;
+                }
+              }
+
+              return false;
+            }
+
+            async function hasActiveLinkedPullRequest(issueNumber, timelineEvents) {
+              try {
+                if (await hasGraphqlLinkedPullRequest(issueNumber)) {
+                  return true;
+                }
+              } catch (error) {
+                core.warning(`GraphQL linked pull request lookup failed for #${issueNumber}: ${error.message}`);
+              }
+
+              const timelinePullRequests = new Set();
+
+              for (const event of timelineEvents) {
+                if (!["cross-referenced", "connected"].includes(event.event)) {
+                  continue;
+                }
+
+                const pullRequestNumber = extractPullRequestNumber(event);
+                if (pullRequestNumber) {
+                  timelinePullRequests.add(pullRequestNumber);
+                }
+              }
+
+              for (const pullRequestNumber of timelinePullRequests) {
+                if (await isActiveOrMergedPullRequest(pullRequestNumber)) {
+                  core.info(`#${issueNumber} is protected by linked pull request #${pullRequestNumber}.`);
+                  return true;
+                }
+              }
+
+              const closingKeywords = ["fix", "fixes", "fixed", "close", "closes", "closed", "resolve", "resolves", "resolved"];
+              for (const keyword of closingKeywords) {
+                const query = `repo:${owner}/${repo} is:pr in:body "${keyword} #${issueNumber}"`;
+                try {
+                  const results = await github.paginate(github.rest.search.issuesAndPullRequests, {
+                    q: query,
+                    per_page: 100,
+                  });
+
+                  for (const result of results) {
+                    if (!result.pull_request) {
+                      continue;
+                    }
+
+                    if (await isActiveOrMergedPullRequest(result.number)) {
+                      core.info(`#${issueNumber} is protected by pull request #${result.number} found with closing keyword search.`);
+                      return true;
+                    }
+                  }
+                } catch (error) {
+                  core.warning(`Search failed for #${issueNumber} using keyword "${keyword}": ${error.message}`);
+                }
+              }
+
+              return false;
+            }
+
+            async function hasExistingExpirationComment(issueNumber) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+
+              return comments.some((comment) => {
+                return comment.user?.type === "Bot" && comment.body?.includes("Your assignment has expired because no linked pull request was opened within 5 days.");
+              });
+            }
+
+            await ensureLabel("waiting-for-pr", "FBCA04", "Assigned issue waiting for a linked pull request.");
+            await ensureLabel("stale-assignment", "B60205", "Assignment expired because no linked pull request was opened in time.");
+
+            const assignedItems = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              assignee: "*",
+              per_page: 100,
+            });
+
+            const assignedIssues = assignedItems.filter((item) => !item.pull_request && item.assignees.length > 0);
+            core.info(`Inspecting ${assignedIssues.length} assigned open issue(s).`);
+
+            for (const issue of assignedIssues) {
+              let timelineEvents;
+              try {
+                timelineEvents = await listTimeline(issue.number);
+              } catch (error) {
+                core.warning(`Skipping #${issue.number}; could not load timeline: ${error.message}`);
+                continue;
+              }
+
+              const hasLinkedPullRequest = await hasActiveLinkedPullRequest(issue.number, timelineEvents);
+              if (hasLinkedPullRequest) {
+                continue;
+              }
+
+              const assignmentDates = latestAssignmentDates(issue, timelineEvents);
+              const expiredAssignees = [];
+
+              for (const [login, assignedAt] of assignmentDates) {
+                const ageMs = now - assignedAt.getTime();
+                core.info(`#${issue.number}: @${login} has been assigned for ${Math.floor(ageMs / (24 * 60 * 60 * 1000))} day(s).`);
+                if (ageMs >= ASSIGNMENT_WINDOW_MS) {
+                  expiredAssignees.push(login);
+                }
+              }
+
+              if (expiredAssignees.length === 0) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeAssignees({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  assignees: expiredAssignees,
+                });
+              } catch (error) {
+                core.warning(`Could not remove expired assignees from #${issue.number}: ${error.message}`);
+                continue;
+              }
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  labels: ["stale-assignment"],
+                });
+              } catch (error) {
+                core.warning(`Could not add stale-assignment label to #${issue.number}: ${error.message}`);
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  name: "waiting-for-pr",
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  core.warning(`Could not remove waiting-for-pr label from #${issue.number}: ${error.message}`);
+                }
+              }
+
+              if (!(await hasExistingExpirationComment(issue.number))) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: "Your assignment has expired because no linked pull request was opened within 5 days.\n\nThe issue is now available for other contributors.",
+                });
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ git clone https://github.com/<your-username>/astrodex.git
 cd astrodex
 
 # 2. Add the upstream remote so you can pull future changes
-git remote add upstream https://github.com/SourabhX16/astrodex.git
+git remote add upstream https://github.com/Omnikon-Org/Astrodex.git
 
 # 3. Install dependencies
 npm install
@@ -65,19 +65,68 @@ git merge upstream/main
 
 ## Claiming an Issue
 
-- **Comment on the issue** expressing interest
-- **We'll assign it within 24-48 hours**
-- If multiple people are interested, preference order:
-  1. Collaboration (joint PR encouraged)
-  2. Experience level (we prioritize helping new contributors)
-  3. First-comment basis (if tied)
+AstroDex uses automated issue assignment to keep work moving and prevent issue hoarding.
 
-- **Timeline:** Once assigned, you have:
-  - **3-5 days** for `easy` labeled issues
-  - **5-7 days** for `intermediate` labeled issues
-  - *Contact us if you need an extension — we're here to support you!*
+### Contributor Claim Command
 
-- **Next step:** Open a **draft PR** to let us know you're working on it. This helps prevent duplicate efforts.
+Comment exactly:
+
+```text
+/assign
+```
+
+The bot will assign the issue to you when:
+
+- The issue is not already assigned
+- You have fewer than **3 active assigned open issues**
+- The comment is on an issue, not a pull request
+
+After a successful claim, the issue receives the `waiting-for-pr` label and the bot confirms your current assignment count.
+
+### Assignment Limits
+
+Each contributor may have up to **3 active assigned open issues** at a time.
+
+If you already have 3 assigned open issues, the bot will not assign another one. Complete one of your current issues before claiming more work.
+
+### Pull Request Deadline
+
+After assignment, open a linked pull request within **5 days**. Link the PR using GitHub-supported issue references such as:
+
+```text
+Fixes #123
+Closes #123
+Resolves #123
+```
+
+GitHub's linked issue UI is also supported.
+
+If no linked pull request is found after 5 days, the assignment is removed automatically, the `stale-assignment` label is added, and the issue becomes available for other contributors.
+
+Closed pull requests that were not merged do not keep an assignment active. Open a new linked PR if you still want to work on the issue.
+
+### Opening Issues
+
+Each contributor may have up to **5 open issues** that they created.
+
+If you open or reopen an issue while you already have more than 5 open issues, the bot will comment and close the newest issue. Please wait until one of your existing issues is resolved before opening another.
+
+### Maintainer Commands
+
+Maintainers can bypass assignment limits with:
+
+```text
+/force-assign @username
+```
+
+Only repository maintainers can use this command. It is intended for manual triage, GSSoC coordination, and cases where maintainers intentionally want to assign work outside the normal contributor limits.
+
+### Automation Labels
+
+The workflows create these labels automatically if they are missing:
+
+- `waiting-for-pr` — assigned issue waiting for a linked pull request
+- `stale-assignment` — assignment expired because no linked pull request was opened in time
 
 ---
 
@@ -380,7 +429,7 @@ If you witness or experience unacceptable behavior, please report it by opening 
 
 ---
 
-[issues]: https://github.com/SourabhX16/astrodex/issues
+[issues]: https://github.com/Omnikon-Org/Astrodex/issues
 [nodejs]: https://nodejs.org
 [npm]: https://www.npmjs.com
 [ts]: https://www.typescriptlang.org


### PR DESCRIPTION
## Summary
- add /assign and maintainer /force-assign automation using actions/github-script
- enforce contributor assignment and open issue limits
- expire stale assignments after 5 days without an active linked PR
- document contributor limits, labels, and maintainer commands

## Verification
- parsed all workflow YAML files locally
- syntax-checked embedded github-script JavaScript with node --check
- ran git diff --check