### PR TITLE
fix: improve sidebar tooltip accessibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -400,3 +400,27 @@ html, body {
   top: calc(var(--header-height) + 16px);
   right: 12px;
 }
+
+/* Accessible tooltip used by compact icon-only controls */
+.tooltip-trigger {
+  display: contents;
+}
+
+.tooltip-bubble {
+  position: fixed;
+  z-index: 80;
+  max-width: min(220px, calc(100vw - 16px));
+  padding: 6px 9px;
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 12, 22, 0.96);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 12px rgba(56, 189, 248, 0.1);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1.3;
+  pointer-events: none;
+  text-transform: uppercase;
+  animation: fadeInUp 0.14s ease-out;
+}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react"
 import { useAppState } from "@/lib/store"
+import { Tooltip } from "@/components/Tooltip"
 
 export function LeftSidebar() {
   const {
@@ -71,15 +72,17 @@ export function LeftSidebar() {
     <>
       {/* Toggle button when collapsed */}
       {!leftSidebarOpen && (
-        <button
-          className="sidebar-toggle sidebar-toggle-left"
-          onClick={toggleLeftSidebar}
-          title="Show Target Panel"
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </button>
+        <Tooltip label="Show Target Panel" placement="right">
+          <button
+            className="sidebar-toggle sidebar-toggle-left"
+            onClick={toggleLeftSidebar}
+            aria-label="Show Target Panel"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 18l6-6-6-6" />
+            </svg>
+          </button>
+        </Tooltip>
       )}
 
       <aside className={`sidebar-left glass-panel ${leftSidebarOpen ? "" : "collapsed"}`}>

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState } from "react"
 import { useAppState, LEO_LIMITS } from "@/lib/store"
 import { visVivaKmPerSec, LEO_DECAY_KM_PER_SEC, hohmannDeltaVKmPerSec, KM_PER_UNIT_CONST } from "@/lib/kepler"
+import { Tooltip } from "@/components/Tooltip"
 
 export function RightSidebar() {
   const {
@@ -108,15 +109,17 @@ export function RightSidebar() {
     <>
       {/* Toggle button when collapsed */}
       {!rightSidebarOpen && (
-        <button
-          className="sidebar-toggle sidebar-toggle-right"
-          onClick={toggleRightSidebar}
-          title="Show Constraints Panel"
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M15 18l-6-6 6-6" />
-          </svg>
-        </button>
+        <Tooltip label="Show Constraints Panel" placement="left">
+          <button
+            className="sidebar-toggle sidebar-toggle-right"
+            onClick={toggleRightSidebar}
+            aria-label="Show Constraints Panel"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          </button>
+        </Tooltip>
       )}
 
       <aside className={`sidebar-right glass-panel ${rightSidebarOpen ? "" : "collapsed"}`}>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react"
+
+type TooltipPlacement = "top" | "right" | "bottom" | "left"
+
+type TooltipProps = {
+  label: string
+  children: ReactNode
+  placement?: TooltipPlacement
+}
+
+const OFFSET = 10
+const VIEWPORT_GAP = 8
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function Tooltip({ label, children, placement = "top" }: TooltipProps) {
+  const tooltipId = useId()
+  const triggerRef = useRef<HTMLSpanElement | null>(null)
+  const bubbleRef = useRef<HTMLSpanElement | null>(null)
+  const [visible, setVisible] = useState(false)
+  const [position, setPosition] = useState({ left: 0, top: 0 })
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current?.firstElementChild
+    const bubble = bubbleRef.current
+    if (!trigger || !bubble) return
+
+    const triggerRect = trigger.getBoundingClientRect()
+    const bubbleRect = bubble.getBoundingClientRect()
+    const centerX = triggerRect.left + triggerRect.width / 2
+    const centerY = triggerRect.top + triggerRect.height / 2
+
+    let left = centerX - bubbleRect.width / 2
+    let top = triggerRect.top - bubbleRect.height - OFFSET
+
+    if (placement === "right") {
+      left = triggerRect.right + OFFSET
+      top = centerY - bubbleRect.height / 2
+    }
+
+    if (placement === "bottom") {
+      left = centerX - bubbleRect.width / 2
+      top = triggerRect.bottom + OFFSET
+    }
+
+    if (placement === "left") {
+      left = triggerRect.left - bubbleRect.width - OFFSET
+      top = centerY - bubbleRect.height / 2
+    }
+
+    setPosition({
+      left: clamp(left, VIEWPORT_GAP, window.innerWidth - bubbleRect.width - VIEWPORT_GAP),
+      top: clamp(top, VIEWPORT_GAP, window.innerHeight - bubbleRect.height - VIEWPORT_GAP),
+    })
+  }, [placement])
+
+  useEffect(() => {
+    if (!visible) return
+
+    updatePosition()
+    window.addEventListener("resize", updatePosition)
+    window.addEventListener("scroll", updatePosition, true)
+
+    return () => {
+      window.removeEventListener("resize", updatePosition)
+      window.removeEventListener("scroll", updatePosition, true)
+    }
+  }, [updatePosition, visible])
+
+  const show = () => setVisible(true)
+  const hide = () => setVisible(false)
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        className="tooltip-trigger"
+        aria-describedby={visible ? tooltipId : undefined}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") hide()
+        }}
+      >
+        {children}
+      </span>
+      {visible && (
+        <span
+          ref={bubbleRef}
+          id={tooltipId}
+          role="tooltip"
+          className="tooltip-bubble"
+          data-placement={placement}
+          style={{
+            left: position.left,
+            top: position.top,
+          }}
+        >
+          {label}
+        </span>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
﻿## Related Issue
Closes #490

---

## Summary
Adds a reusable accessible Tooltip component for compact icon-only controls and applies it to the collapsed left and right sidebar toggles.

The tooltip now:
- appears on hover and keyboard focus
- dismisses on blur, mouse leave, or Escape
- clamps its fixed position inside the viewport
- keeps icon-only buttons labeled with `aria-label`

---

## Proposed Labels
- UI/UX
- accessibility

---

## Core Files Changed
- `src/components/Tooltip.tsx`
- `src/components/LeftSidebar.tsx`
- `src/components/RightSidebar.tsx`
- `src/app/globals.css`

---

## Verification
- `npx.cmd eslint src/components/Tooltip.tsx src/components/LeftSidebar.tsx src/components/RightSidebar.tsx` passed.
- `npx.cmd tsc --noEmit` passed.
- `npm.cmd run build` passed.
- Full `npm.cmd run lint` still stops on pre-existing React Compiler findings in Earth shader components outside this PR scope.

---

## AI Assistance Declaration
AI used: Yes

Model: GPT-5
Platform: Codex
What AI did: helped inspect the assigned issue, implement the reusable tooltip component, wire it into sidebar controls, and run validation commands.
What I did: reviewed the assigned scope, validated the changes locally, and confirmed the PR stays limited to the GSSoC task.
Advantage: faster focused accessibility iteration while preserving project conventions and verification discipline.

---

## Reviewer Notes
The touched Tooltip and Sidebar files pass targeted ESLint, TypeScript, and production build. The remaining full-lint findings are outside these changed files.

---

## Pledge
- [x] I have tested these changes in my own local branch.
- [x] I verified this code compiles into a standalone build and does not break existing production behavior.
