### PR TITLE
Analyze the Scene Content provide

### DIFF
--- a/src/components/AsteroidCard.tsx
+++ b/src/components/AsteroidCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useAppState } from "@/lib/store"
+import { useEffect } from "react"
 
 export function AsteroidCard() {
   const {
@@ -10,6 +11,14 @@ export function AsteroidCard() {
     leftSidebarOpen,
     selectAsteroid,
   } = useAppState()
+  useEffect(() => {
+  if (!selectedAsteroid) return
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") selectAsteroid(null)
+  }
+  document.addEventListener("keydown", onKeyDown)
+  return () => document.removeEventListener("keydown", onKeyDown)
+}, [selectedAsteroid, selectAsteroid])
 
   if (!selectedAsteroid) return null
 
@@ -67,6 +76,7 @@ export function AsteroidCard() {
         <button
           className="btn-ghost"
           onClick={() => selectAsteroid(null)}
+          aria-label="Close asteroid Card"
           style={{ padding: 4, border: "none" }}
         >
           <svg

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -136,7 +136,9 @@ export function RightSidebar() {
             }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <button className="btn-ghost" onClick={toggleRightSidebar} style={{ padding: 4, border: "none" }}>
+              <button className="btn-ghost" onClick={toggleRightSidebar} 
+              aria-label="Hide Constraints Panel"
+              style={{ padding: 4, border: "none" }}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M9 18l6-6-6-6" />
                 </svg>

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -59,7 +59,7 @@ function SceneContent() {
 
 export function Scene() {
   return (
-    <div className="fixed inset-0 z-0">
+    <div className="fixed inset-0 z-0" aria-hidden="true">
       <Canvas
         camera={{ position: [0, 0, 6], fov: 45, near: 0.1, far: 100 }}
         gl={{ antialias: true, alpha: false }}


### PR DESCRIPTION
🔗Related Issue
Closes #518 

Description of Changes
 Accessibility pass on the Scene component and its immediate UI, addressing keyboard navigation and screen reader support as requested in the issue.

Scene.tsx: Added aria-hidden="true" to the canvas wrapper div. The WebGL canvas has no accessible DOM content (it's a 3D scene rendered as a single bitmap), so screen readers were either skipping it silently or announcing unhelpful noise. This marks it correctly as decorative to assistive tech, with no visual change.

AsteroidCard.tsx:

Added aria-label="Close asteroid inspector" to the icon-only close button, which previously had no accessible name (screen readers announced just "button").
Added a keyboard Escape handler so the inspector panel can now be dismissed without a mouse — previously the only way to close it was clicking the small X icon.


RightSidebar.tsx: Added aria-label="Hide Constraints Panel" to the inner collapse toggle button. 


🏷️ Proposed Labels

- [x]  UI/UX


📂 Core Files Changed

src/components/Scene.tsx
src/components/AsteroidCard.tsx
src/components/RightSidebar.tsx



🤖 AI Assistance Declaration
Did you use an AI tool to write or assist with this code OR Pull Request?

 Yes


Which AI Model did you use? Claude 
What exactly did the AI do? Helped identify likely accessibility gaps.

What exactly did YOU do? Forked the repo, understood the codebase, Located the relevant files, applied the changes to the actual codebase in VS code, resolved a duplicate-import bug that came up during implementation, ran and tested the app locally, and verified behavior with a screen reader before submitting.

What is the advantage of using this AI approach here? faster focused accessibility changes while preserving project conventions and verification discipline.



✅ The "I Swear I Didn't Break Anything" Pledge

- [x]  I have thoroughly tested these changes in my own local branch.

 

- [x] I verified multiple times that this code compiles into a standalone build and does not break existing production features.