### PR TITLE
refactor: decouple loading skeleton UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -287,7 +287,14 @@ html, body {
     transform: translateX(0);
   }
 }
-
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
 @keyframes pulseGlow {
   0%, 100% {
     box-shadow: 0 0 4px rgba(56, 189, 248, 0.4);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -287,6 +287,8 @@ html, body {
     transform: translateX(0);
   }
 }
+
+/* Spinner animation for loading skeleton */
 @keyframes spin {
   from {
     transform: rotate(0deg);
@@ -295,6 +297,7 @@ html, body {
     transform: rotate(360deg);
   }
 }
+
 @keyframes pulseGlow {
   0%, 100% {
     box-shadow: 0 0 4px rgba(56, 189, 248, 0.4);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,11 @@ import { LeftSidebar } from "@/components/LeftSidebar"
 import { RightSidebar } from "@/components/RightSidebar"
 import { AgentTerminal } from "@/components/AgentTerminal"
 import { AsteroidCard } from "@/components/AsteroidCard"
+import { LoadingSkeleton } from "@/components/LoadingSkeleton"
 
 const Scene = dynamic(() => import("@/components/Scene").then((m) => ({ default: m.Scene })), {
   ssr: false,
+  loading: () => <LoadingSkeleton />,
 })
 
 export default function Home() {

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+export function LoadingSkeleton() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-deep)",
+        zIndex: 40,
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+        <div
+          className="animate-pulse-glow"
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: "50%",
+            border: "2px solid var(--accent-cyan)",
+            borderTopColor: "transparent",
+            animation: "spin 0.9s linear infinite",
+          }}
+        />
+        <span
+          style={{
+            fontSize: 12,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono), monospace",
+          }}
+        >
+          Initializing Orbit Systems...
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,6 +1,20 @@
 "use client"
 
+/**
+ * Loading skeleton displayed while the 3D Scene component is dynamically importing.
+ * Provides immediate visual feedback to users during initial page load.
+ * Respects user motion preferences for accessibility compliance.
+ */
+
+const SPINNER_ANIMATION_DURATION = "0.9s"
+
 export function LoadingSkeleton() {
+  // Respect user's motion preferences for accessibility
+  const prefersReducedMotion =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false
+
   return (
     <div
       style={{
@@ -13,7 +27,14 @@ export function LoadingSkeleton() {
         zIndex: 40,
       }}
     >
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 16,
+        }}
+      >
         <div
           className="animate-pulse-glow"
           style={{
@@ -22,7 +43,9 @@ export function LoadingSkeleton() {
             borderRadius: "50%",
             border: "2px solid var(--accent-cyan)",
             borderTopColor: "transparent",
-            animation: "spin 0.9s linear infinite",
+            animation: prefersReducedMotion
+              ? "none"
+              : `spin ${SPINNER_ANIMATION_DURATION} linear infinite`,
           }}
         />
         <span


### PR DESCRIPTION
## 🔗 Related Issue
Closes #527

---

## 📝 Description of Changes
- Created a reusable `LoadingSkeleton` component.
- Updated the dynamic import in `src/app/page.tsx` to use the reusable loading component.
- Added the `spin` animation required by the loading component.

---
## 🏷️ Proposed Labels
-✅UI/UX
- [ ] Documentation
- [ ] CI/CD
- [ ] Backend Logic
- [ ] Anything else

---
## 📂 Core Files Changed
src/components/LoadingSkeleton.tsx
src/app/page.tsx
src/app/globals.css

---
## 📸 Verification & Screenshots
Verified locally using npm run dev.
The loading screen appears briefly while the 3D scene initializes, and the application loads successfully.
---
 
## ⚠️ Reviewer Notes
Tested locally using npm run dev. The application runs successfully and the loading component appears during scene initialization.

---

## ✅ The "I Swear I Didn't Break Anything" Pledge
-✅I have thoroughly tested these changes in my own local branch.
- [ ] I verified multiple times that this code compiles into a standalone build and does not break existing production features.
