### PR TITLE
chore: annotate WebGL loading spinner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { AsteroidCard } from "@/components/AsteroidCard"
 import { LoadingSkeleton } from "@/components/LoadingSkeleton"
 
 const Scene = dynamic(() => import("@/components/Scene").then((m) => ({ default: m.Scene })), {
+  // The WebGL canvas relies on browser APIs, so keep it client-only and show
+  // the lightweight spinner while the scene bundle loads.
   ssr: false,
   loading: () => <LoadingSkeleton />,
 })

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -9,7 +9,7 @@
 const SPINNER_ANIMATION_DURATION = "0.9s"
 
 export function LoadingSkeleton() {
-  // Respect user's motion preferences for accessibility
+  // Avoid running the rotation animation when the user asks for reduced motion.
   const prefersReducedMotion =
     typeof window !== "undefined"
       ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
@@ -41,6 +41,8 @@ export function LoadingSkeleton() {
             width: 48,
             height: 48,
             borderRadius: "50%",
+            // The transparent top border creates the orbital sweep while the
+            // shared `spin` keyframe rotates the full ring.
             border: "2px solid var(--accent-cyan)",
             borderTopColor: "transparent",
             animation: prefersReducedMotion


### PR DESCRIPTION
﻿## Related Ticket
Closes #289

---

## Change Summary
Adds concise inline notes for the WebGL loading spinner path:

- explains why the WebGL `Scene` loads as a client-only component
- clarifies that `LoadingSkeleton` is the lightweight spinner fallback while the scene bundle loads
- explains the reduced-motion guard and spinner border animation technique

No runtime behavior was changed.

---
## Proposed Labels
- [ ] UI/UX
- [x] Maintainer note update
- [ ] CI/CD
- [ ] Backend Logic
- [ ] Anything else

---
## Core Files Changed
- `src/app/page.tsx`
- `src/components/LoadingSkeleton.tsx`

---
## Verification & Screenshots
- **UI/UX (User Interface / User Experience - how it looks and feels):**
  - No visual behavior changes; note-only update for the existing loading spinner fallback.

- **CI/CD (Continuous Integration / Continuous Deployment - the automated build/test pipeline):**
  - `npx.cmd eslint src/app/page.tsx src/components/LoadingSkeleton.tsx` passed.
  - `npm.cmd run build` passed.
  - `npm.cmd run lint` currently fails on pre-existing unrelated files: `src/components/earth/Atmosphere.tsx`, `src/components/earth/CloudLayer.tsx`, and `src/components/earth/Earth.tsx` React hook/compiler lint rules; these files are not touched in this PR.

---
## AI Assistance Declaration
**Did you use an AI tool to write or assist with this code OR Pull Request?**
- [x] Yes
- [ ] No

* **Which AI Model did you use?**: GPT-5 Codex
* **Which Platform/Tool?**: Codex
* **What exactly did the AI do?**: Assisted with inspecting the assigned ticket, identifying the WebGL loading spinner path, adding concise inline comments, and running local verification commands.
* **What exactly did YOU do?**: Reviewed the ticket scope, accepted the focused comment changes, and submitted the PR from my GitHub account.
* **What is the advantage of using this AI approach here?**: It kept the change small, scoped, and verification-driven while avoiding unrelated code churn.

---

## Reviewer Notes
This PR intentionally avoids touching the existing earth shader lint blockers so the change remains scoped to #289.

---

## The Pledge
- [x] I have thoroughly tested these changes in my own local branch.
- [x] I verified multiple times that this code compiles into a standalone build and does not break existing production behavior.
