### PR TITLE
fix: make Pause Simulation actually pause via delta-accumulator sim clock (#550)

### DIFF
--- a/src/components/AsteroidField.tsx
+++ b/src/components/AsteroidField.tsx
@@ -125,6 +125,13 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
   const asteroidTierCountsRef = useRef<[number, number, number]>([0, 0, 0])
   const debrisTierCountsRef = useRef<[number, number, number]>([0, 0, 0])
   const frameCounterRef = useRef(0)
+  // Paused-time-aware sim clock. R3F's `state.clock.getElapsedTime()` keeps
+  // advancing while `simulationRunning` is false, so on resume every asteroid
+  // and debris piece used to teleport to where it would have been if the sim
+  // had never paused. This ref only advances when simulationRunning is true,
+  // and the mean-anomaly propagation for every one of the 600 objects now
+  // derives its time from here. See issue #550.
+  const simTimeRef = useRef(0)
 
   const generated = useMemo(() => {
     const d: AsteroidData[] = []
@@ -177,10 +184,17 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
     }
   }, [asteroidGeometries, debrisGeometries])
 
-  useFrame((state) => {
+  useFrame((state, delta) => {
     const selectedIdx = getSelectedIndex()
+    // Wall-clock time — used only for the conjunction-alert throttle and the
+    // at-risk pulsing red visual, both of which should keep ticking even
+    // while the sim is paused (a throttle that pauses would fire a burst
+    // of duplicate alerts on resume; the pulse is UI feedback, not physics).
     const t = state.clock.getElapsedTime()
-    const elapsedSceneTime = t * SCENE_TIME_SCALE
+    if (simulationRunning) {
+      simTimeRef.current += delta
+    }
+    const elapsedSceneTime = simTimeRef.current * SCENE_TIME_SCALE
     const shouldRebucket = frameCounterRef.current % LOD_REBUCKET_INTERVAL === 0
     frameCounterRef.current += 1
 

--- a/src/components/SatelliteSystem.tsx
+++ b/src/components/SatelliteSystem.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useMemo } from "react"
+import { useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 import { useAppState } from "@/lib/store"
@@ -94,6 +94,12 @@ export function SatelliteSystem() {
   const issRef = useRef<THREE.Mesh>(null)
   const envisatRef = useRef<THREE.Mesh>(null)
   const hubbleRef = useRef<THREE.Mesh>(null)
+  // Paused-time-aware sim clock. R3F's `state.clock.getElapsedTime()` keeps
+  // advancing while `simulationRunning` is false, so on resume every satellite
+  // used to teleport to where it would have been if the sim had never paused.
+  // This ref only advances when simulationRunning is true, and every Kepler
+  // solve now derives its mean anomaly from it. See issue #550.
+  const simTimeRef = useRef(0)
 
   // Convert km altitude to 3D scene units (Earth radius is 1.8 units = 6378 km)
   const issRadius = useMemo(() => 1.8 + kmToSceneUnits(satAltitude), [satAltitude])
@@ -108,10 +114,11 @@ export function SatelliteSystem() {
   const envisatOrbitGeo = useMemo(() => createOrbitGeometry(envisatRadius, 0.0006, 98.54, 120), [envisatRadius])
   const hubbleOrbitGeo = useMemo(() => createOrbitGeometry(hubbleRadius, 0.0003, 28.5, 45), [hubbleRadius])
 
-  useFrame((state, delta) => {
+  useFrame((_state, delta) => {
     if (!simulationRunning) return
 
-    const time = state.clock.getElapsedTime()
+    simTimeRef.current += delta
+    const time = simTimeRef.current
     const tempPos = new THREE.Vector3()
 
     // LEO atmospheric drag — slowly drop the ISS altitude in real time


### PR DESCRIPTION
### Summary

Both \`SatelliteSystem.useFrame\` and \`AsteroidField.useFrame\` derived their Kepler mean anomaly from \`state.clock.getElapsedTime()\` — R3F's wall clock, which **keeps advancing while \`simulationRunning\` is false**. On resume every satellite, asteroid, and debris piece teleported to where it would have been if the sim had never paused. The Header explicitly shows "PAUSED" during the pause, but the physics silently disagreed.

### What changed

- Added a \`simTimeRef\` \`useRef(0)\` in both \`SatelliteSystem.tsx\` and \`AsteroidField.tsx\`.
- The ref only accumulates \`delta\` (the R3F per-frame delta) while \`simulationRunning\` is true.
- Every Kepler solve now derives its \`time\` from \`simTimeRef.current\` instead of \`state.clock.getElapsedTime()\`.
- Result: pause freezes physics. Resume picks up exactly where it left off.

### Why the wall clock is intentionally preserved for 2 use cases in AsteroidField

- **Conjunction-alert throttle** (\`t - lastAlert > 8\`): must tick during pause. Otherwise the timer bunches up and fires a burst of duplicate alerts on resume.
- **At-risk pulsing red visual** (\`Math.sin(t * 8)\`): UI feedback, not physics. Users should still see the red-alert pulse while paused.

Both are documented inline.

### Files changed

- \`src/components/SatelliteSystem.tsx\`
- \`src/components/AsteroidField.tsx\`

### Test plan

- [x] \`tsc --noEmit\` clean on both files
- [ ] once approved: hit Run → wait 10s → hit Pause → wait 10s → hit Run → confirm objects continue from where they were, not from where they would have been without pause. verify pulsing red still animates during pause. verify no burst of duplicate conjunction alerts on resume.

Fixes #550