### PR TITLE
fix: propagate the selected asteroid's orbit instead of freezing it (#551)

### DIFF
--- a/src/components/AsteroidField.tsx
+++ b/src/components/AsteroidField.tsx
@@ -210,7 +210,16 @@ export function AsteroidField({ onAsteroidClick, getSelectedIndex }: AsteroidFie
       const baseColors = isDebris ? DEBRIS_COLORS : ASTEROID_COLORS
 
       // 1. Keplerian propagation: M = n·t + M0  →  solve Kepler for E
-      if (selectedIdx !== i && simulationRunning) {
+      // Previously this branch was `selectedIdx !== i && simulationRunning`,
+      // which meant the currently selected object's eccentric anomaly stopped
+      // advancing the moment the user clicked it. Its position froze, the
+      // Vis-Viva HUD readout locked to a single km/s value, and conjunction
+      // checks under-reported collisions against the object the user was
+      // inspecting (see issue #551). Propagate for every object; the
+      // per-object work here is cheap and the AGENTS docs explicitly promise
+      // "propagation happening for each of 600 objects" with no carve-out
+      // for the selected one.
+      if (simulationRunning) {
         const n = meanMotion(ad.orbitRadius)
         anglesRef.current[i] = solveKepler(n * elapsedSceneTime + ad.meanAnomaly0, ad.eccentricity)
       }


### PR DESCRIPTION
### Summary

\`AsteroidField.useFrame\` gated per-object Keplerian propagation on \`selectedIdx !== i && simulationRunning\`, which meant the currently selected asteroid stopped advancing its eccentric anomaly the moment the user clicked it. Its position froze, its Vis-Viva km/s HUD readout locked to a single value, neighbouring bodies visually drifted past it, and the conjunction alerter under-reported collisions against the very object the user was inspecting.

### What changed

Dropped the \`selectedIdx !== i\` half of the guard. Propagation now runs for every object regardless of selection.

\`\`\`diff
-      if (selectedIdx !== i && simulationRunning) {
+      if (simulationRunning) {
         const n = meanMotion(ad.orbitRadius)
         anglesRef.current[i] = solveKepler(n * elapsedSceneTime + ad.meanAnomaly0, ad.eccentricity)
       }
\`\`\`

### Why the change matches the docs

- \`AsteroidField.tsx:66\` comment: \`"velocity: 0.0 km/s // overwritten on first frame from Vis-Viva"\`
- \`AGENTS.md\`: *"The \`velocity\` string is overwritten each frame from the live Vis-Viva speed when the object is selected"*
- \`ARCHITECTURE.md\` lines 158-166 describes propagation happening *"For each of 600 objects"* with no carve-out for the selected one, and shows \`v = visViva(√(x²+y²+z²), a)\` implying \`r\` must evolve

The old guard contradicted all three.

### Test plan

- [x] \`tsc --noEmit\` clean
- [ ] once approved: click any asteroid → confirm it keeps orbiting, the km/s readout oscillates between perigee/apogee speeds (for eccentric orbits \`e ≈ 0.28\`), and conjunction alerts fire when its orbit passes close to a satellite

Fixes #551