### PR TITLE
fix: refactor font loader

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,14 @@
 @import "tailwindcss";
 
 @theme inline {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-jetbrains-mono);
+  --font-sans: var(--font-sans-stack);
+  --font-mono: var(--font-mono-stack);
 }
 
 /* ─── Mission Control Design Tokens ─── */
 :root {
+  --font-sans-stack: "Geist", "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono-stack: "JetBrains Mono", "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --bg-deep: #060a13;
   --bg-panel: rgba(10, 16, 28, 0.85);
   --bg-panel-solid: #0c1220;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next"
-import { Geist, JetBrains_Mono } from "next/font/google"
 import "./globals.css"
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-})
-
-const jetbrainsMono = JetBrains_Mono({
-  variable: "--font-jetbrains-mono",
-  subsets: ["latin"],
-})
 
 export const metadata: Metadata = {
   title: "AstroDex — Interactive 3D Asteroid Explorer",
@@ -24,7 +13,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en">
       <body>{children}</body>
     </html>
   )


### PR DESCRIPTION
## Summary
- removes the `next/font/google` runtime font loader from the root layout
- replaces the generated font variables with CSS-defined system-first font stacks
- keeps the existing `--font-sans` and `--font-mono` usage intact across the app

## Why
The previous root layout depended on Google font loading classes for the entire app shell. On mobile or constrained networks, that can delay or jolt the initial render. Defining resilient font stacks in CSS lets the UI paint immediately while preserving the intended Geist / JetBrains Mono look when those fonts are available locally.

Fixes #521

## Validation
- `npm.cmd test` - 20 passed
- `npm.cmd run build` - passed
- `npx.cmd eslint src/app/layout.tsx` - passed

Note: full `npm.cmd run lint` still reports pre-existing issues in `src/components/earth/Atmosphere.tsx`, `src/components/earth/CloudLayer.tsx`, `src/components/earth/Earth.tsx`, plus unrelated unused-variable warnings. Those files were not touched by this PR.
