### PR TITLE
fix(theme): improve dark mode text contrast for accessibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,8 +16,8 @@
   --border-focus: rgba(56, 189, 248, 0.4);
   --text-primary: rgba(255, 255, 255, 0.92);
   --text-secondary: rgba(255, 255, 255, 0.6);
-  --text-muted: rgba(255, 255, 255, 0.35);
-  --text-label: rgba(255, 255, 255, 0.45);
+  --text-muted: rgba(255, 255, 255, 0.48);
+  --text-label: rgba(255, 255, 255, 0.47);
   --accent-cyan: #38bdf8;
   --accent-cyan-dim: rgba(56, 189, 248, 0.15);
   --accent-green: #34d399;


### PR DESCRIPTION
Description:
The dark mode text colors didn't have enough contrast against the background, making some UI text hard to read.
I fixed this by increasing the opacity of two text color variables (--text-muted and --text-label) in globals.css, so they now meet accessibility contrast standards (WCAG AA):

--text-muted: contrast went from ~3.14:1 → 5.00:1
--text-label: contrast went from ~4.48:1 → 4.81:1

Everything else (main text, accent colors, panels, borders) was left untouched.
Closes #42