### PR TITLE
docs: explain CloudLayer shader

### DIFF
--- a/src/components/earth/CloudLayer.tsx
+++ b/src/components/earth/CloudLayer.tsx
@@ -13,6 +13,8 @@ varying vec3 vPosition;
 varying float vCloudDensity;
 
 void main() {
+  // Sample the grayscale cloud map and push denser pixels slightly above the
+  // Earth sphere so the layer has visible volume at the day/night boundary.
   vUv = uv;
   vNormal = normalize(normalMatrix * normal);
   float cloudDensity = texture2D(cloudTexture, uv).r;
@@ -34,6 +36,8 @@ varying vec3 vPosition;
 varying float vCloudDensity;
 
 void main() {
+  // Use the red channel as both cloud coverage and opacity. Lighting remains
+  // directional so clouds brighten on the sun-facing side of the planet.
   vec4 cloudColor = texture2D(cloudTexture, vUv);
   float alpha = cloudColor.r * 0.65;
 
@@ -52,6 +56,13 @@ interface CloudLayerProps {
   sunDirection: THREE.Vector3
 }
 
+/**
+ * Renders the procedural cloud shell around Earth.
+ *
+ * The texture is created once per sun-direction setup, while the mesh rotates
+ * in the frame loop. Transparent blending and disabled depth writes keep the
+ * shell from hiding satellites or the atmosphere behind sparse cloud pixels.
+ */
 export function CloudLayer({ sunDirection }: CloudLayerProps) {
   const meshRef = useRef<THREE.Mesh>(null)
 


### PR DESCRIPTION
## Summary
- document cloud density displacement in the vertex shader
- explain directional alpha and lighting in the fragment shader
- document how the procedural texture and rotating shell fit together

Fixes #223

## Validation
- `git diff --check`
- `npx eslint src/components/earth/CloudLayer.tsx` *(blocked by the pre-existing uniforms mutation at line 76)*