### PR TITLE
refactor: simplify camera tracking lerp logic

### DIFF
--- a/src/components/CameraController.tsx
+++ b/src/components/CameraController.tsx
@@ -16,31 +16,26 @@ export function CameraController() {
   const { selectedAsteroid, resetCamera, clearReset } = useAppState()
   const targetPos = useRef(EARTH_POSITION.clone())
   const targetLook = useRef(EARTH_TARGET.clone())
-  const hasSelection = useRef(false)
+  
 
   useEffect(() => {
     if (resetCamera) {
-      hasSelection.current = false
-      targetPos.current.copy(EARTH_POSITION)
-      targetLook.current.copy(EARTH_TARGET)
       clearReset()
     }
   }, [resetCamera, clearReset])
 
-  useEffect(() => {
-    if (selectedAsteroid) {
-      hasSelection.current = true
-    }
-  }, [selectedAsteroid])
 
   useFrame((_, delta) => {
-    if (hasSelection.current) {
+    if (selectedAsteroid) {
       const pos = trackedPosition.current
       if (pos.lengthSq() > 0) {
         targetLook.current.copy(pos)
         _offset.copy(pos).normalize().multiplyScalar(1.5)
         targetPos.current.copy(pos).add(_offset)
       }
+    } else{
+      targetPos.current.copy(EARTH_POSITION)
+      targetLook.current.copy(EARTH_TARGET)
     }
 
     camera.position.lerp(targetPos.current, 3 * delta)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #520

---

## 📝 Description of Changes

Refactored the camera logic in CameraController to make it cleaner and easier to maintain.

- Removed the unnecessary `hasSelection` ref.
- Eliminated the extra `useEffect` hooks and handled the camera logic directly inside `useFrame`.
- The camera now follows the selected asteroid, and falls back to Earth when nothing is selected or after a reset.
- Left a single `useEffect` to reset the `resetCamera` flag in the global store.
- Reduced overall complexity and improved readability.


## 🏷️ Proposed Labels
- [ ] UI/UX
- [ ] Documentation
- [ ] CI/CD
- [ ] Backend Logic
- [X] Anything else(Refactoring/Code Simplification)

---
## 📂 Core Files Changed
- [CameraController.tsx]

---
## 📸 Verification & Screenshots
- **UI/UX (User Interface / User Experience - how it looks and feels):**
-  No visual/UI changes.
  - Verified that:
    - Selecting an asteroid makes the camera smoothly follow it.
    - Deselecting an asteroid returns the camera to Earth.
    - Camera reset continues to work as expected.
  
- **CI/CD (Continuous Integration / Continuous Deployment - the automated build/test pipeline):**

---
## 🤖 AI Assistance Declaration
**Did you use an AI tool to write or assist with this code OR Pull Request?**
- [ ] Yes
- [X] No (If no, you can skip the rest of this section)

> **⚠️ IF YOU CHECKED "YES", YOU MUST ANSWER THE FOLLOWING:**
* **Which AI Model did you use?** *(e.g., GPT-4o, Claude 4.5 Sonnet)*: 
* **Which Platform/Tool?** *(e.g., Cursor, OpenCode, Codex, Claude Code, GitHub Copilot, standard web chat)*: 
* **What exactly did the AI do?**: 
* **What exactly did YOU do?**: 
* **What is the advantage of using this AI approach here?**:
  
---

## ⚠️ Reviewer Notes

None


## ✅ The "I Swear I Didn't Break Anything" Pledge
- [X] I have thoroughly tested these changes in my own local branch.
- [X] I verified multiple times that this code compiles into a standalone build and does not break existing production features.
