### PR TITLE
fix: harden vis-viva speed calculation

### DIFF
--- a/src/lib/__tests__/kepler.test.ts
+++ b/src/lib/__tests__/kepler.test.ts
@@ -106,6 +106,18 @@ describe("visViva", () => {
     expect(speed).toBeGreaterThan(0)
     expect(speed).toBeCloseTo(Math.sqrt(0.005 * (2 / 1.8 - 1 / 2.2)), 12)
   })
+
+  it("returns zero for invalid scene-unit orbit parameters", () => {
+    expect(visViva(0, 2.2)).toBe(0)
+    expect(visViva(1.8, 0)).toBe(0)
+    expect(visViva(Number.NaN, 2.2)).toBe(0)
+  })
+
+  it("returns zero for invalid kilometer orbit parameters", () => {
+    expect(visVivaKmPerSec(0, 6371)).toBe(0)
+    expect(visVivaKmPerSec(6371, 0)).toBe(0)
+    expect(visVivaKmPerSec(Number.POSITIVE_INFINITY, 6371)).toBe(0)
+  })
 })
 
 describe("meanMotion", () => {

--- a/src/lib/kepler.ts
+++ b/src/lib/kepler.ts
@@ -16,7 +16,18 @@
  */
 
 const MU_EARTH_KM = 3.986e5 // km³/s²
+const MU_SCENE = 0.005
 const KM_PER_UNIT = 3543 // 1 scene unit = 3543 km (Earth radius 6378 km = 1.8 units)
+
+function visVivaSpeed(mu: number, radius: number, semiMajorAxis: number): number {
+  if (!Number.isFinite(radius) || !Number.isFinite(semiMajorAxis) || radius <= 0 || semiMajorAxis <= 0) {
+    return 0
+  }
+
+  const radicand = mu * (2 / radius - 1 / semiMajorAxis)
+
+  return Math.sqrt(Math.max(0, radicand))
+}
 
 /**
  * Time scaling factor: scene seconds per real second.
@@ -67,7 +78,6 @@ export function meanMotion(a: number): number {
   // (a ≈ 1.91 units, 400 km altitude) yields a period of ~60 scene-seconds
   // when scaled by SCENE_TIME_SCALE.  Derived empirically:
   //   μ_scene = 0.005  →  n(1.91) ≈ 0.0267 rad/s,  period ≈ 235 s raw.
-  const MU_SCENE = 0.005
   return Math.sqrt(MU_SCENE / (a * a * a))
 }
 
@@ -79,8 +89,7 @@ export function meanMotion(a: number): number {
  *     v = sqrt( μ·(2/r − 1/a) )
  */
 export function visViva(r: number, a: number): number {
-  const MU_SCENE = 0.005
-  return Math.sqrt(Math.max(0, MU_SCENE * (2 / r - 1 / a)))
+  return visVivaSpeed(MU_SCENE, r, a)
 }
 
 /**
@@ -88,7 +97,7 @@ export function visViva(r: number, a: number): number {
  * Inspector telemetry readout where users expect km/s.
  */
 export function visVivaKmPerSec(rKm: number, aKm: number): number {
-  return Math.sqrt(Math.max(0, MU_EARTH_KM * (2 / rKm - 1 / aKm)))
+  return visVivaSpeed(MU_EARTH_KM, rKm, aKm)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract the shared Vis-Viva speed formula into a single helper used by scene-unit and km/s calculations
- Reuse the scene gravitational constant instead of redeclaring it inside each caller
- Guard invalid/non-finite radius or semi-major-axis inputs so telemetry returns `0` instead of `Infinity`/`NaN`
- Add focused regression coverage for invalid scene-unit and kilometer inputs

Fixes #530

## Validation
- `npm.cmd test -- src/lib/__tests__/kepler.test.ts` (22 passed)
- `npm.cmd test` (22 passed)
- `npm.cmd run build` (passed)
- `git diff --check` (passed)

## Note
- `npm.cmd run lint` is currently blocked by pre-existing unrelated lint errors outside this PR in `src/components/earth/Atmosphere.tsx`, `src/components/earth/CloudLayer.tsx`, and `src/components/earth/Earth.tsx`, plus unrelated unused-variable warnings. This PR only changes `src/lib/kepler.ts` and its focused tests.