### PR TITLE
perf: automate loading spinner motion

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -343,6 +343,16 @@ html, body {
   animation: pulseGlow 2s ease-in-out infinite;
 }
 
+.loading-spinner {
+  animation: spin 0.9s linear infinite, pulseGlow 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation: none;
+  }
+}
+
 .animate-terminal-blink {
   animation: terminalBlink 1s step-end infinite;
 }

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,20 +1,10 @@
-"use client"
-
 /**
  * Loading skeleton displayed while the 3D Scene component is dynamically importing.
  * Provides immediate visual feedback to users during initial page load.
  * Respects user motion preferences for accessibility compliance.
  */
 
-const SPINNER_ANIMATION_DURATION = "0.9s"
-
 export function LoadingSkeleton() {
-  // Avoid running the rotation animation when the user asks for reduced motion.
-  const prefersReducedMotion =
-    typeof window !== "undefined"
-      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
-      : false
-
   return (
     <div
       style={{
@@ -36,7 +26,7 @@ export function LoadingSkeleton() {
         }}
       >
         <div
-          className="animate-pulse-glow"
+          className="loading-spinner"
           style={{
             width: 48,
             height: 48,
@@ -45,9 +35,6 @@ export function LoadingSkeleton() {
             // shared `spin` keyframe rotates the full ring.
             border: "2px solid var(--accent-cyan)",
             borderTopColor: "transparent",
-            animation: prefersReducedMotion
-              ? "none"
-              : `spin ${SPINNER_ANIMATION_DURATION} linear infinite`,
           }}
         />
         <span


### PR DESCRIPTION
## Summary
- remove the client-only boundary and `window.matchMedia` runtime read from the WebGL loading fallback
- move spinner motion and reduced-motion handling into CSS
- preserve the same orbital ring visual while trimming client-side fallback code

Closes #517

## Validation
- `npm.cmd test` passed: 1 file, 22 tests
- `npm.cmd run build` passed
- `git diff --check` passed
- `npm.cmd run lint` still reports pre-existing unrelated issues in `src/components/Scene.tsx`, `src/components/earth/Atmosphere.tsx`, `src/components/earth/CloudLayer.tsx`, `src/components/earth/Earth.tsx`, and `src/components/earth/textures.ts`