### PR TITLE
Fix #67: add subtle camera transition shake

### DIFF
--- a/src/components/CameraController.tsx
+++ b/src/components/CameraController.tsx
@@ -10,12 +10,15 @@ const EARTH_POSITION = new THREE.Vector3(0, 0, 6)
 const EARTH_TARGET = new THREE.Vector3(0, 0, 0)
 const _offset = new THREE.Vector3()
 const _lookTarget = new THREE.Vector3()
+const _shake = new THREE.Vector3()
 
 export function CameraController() {
   const { camera } = useThree()
   const { selectedAsteroid, resetCamera, clearReset } = useAppState()
   const targetPos = useRef(EARTH_POSITION.clone())
   const targetLook = useRef(EARTH_TARGET.clone())
+  const lastTargetPos = useRef(EARTH_POSITION.clone())
+  const shakeTime = useRef(0)
   
 
   useEffect(() => {
@@ -38,8 +41,22 @@ export function CameraController() {
       targetLook.current.copy(EARTH_TARGET)
     }
 
+    const jumpDistance = targetPos.current.distanceTo(lastTargetPos.current)
+    if (jumpDistance > 0.6) shakeTime.current = Math.min(0.35, jumpDistance * 0.08)
+    lastTargetPos.current.copy(targetPos.current)
+
     camera.position.lerp(targetPos.current, 3 * delta)
     _lookTarget.copy(targetLook.current)
+    if (shakeTime.current > 0) {
+      const amp = shakeTime.current * 0.018
+      _shake.set(
+        Math.sin(shakeTime.current * 80) * amp,
+        Math.cos(shakeTime.current * 97) * amp,
+        0
+      )
+      camera.position.add(_shake)
+      shakeTime.current = Math.max(0, shakeTime.current - delta)
+    }
     camera.lookAt(_lookTarget)
   })
 


### PR DESCRIPTION
## Summary
- detect large camera target jumps during object tracking
- add a short damped shake offset during high-speed transitions
- keep the existing lerp-based camera tracking behavior

Closes #67

## Verification
- npm run lint
- npm run build
- npm test