### PR TITLE
Fix #69: add chromatic aberration post-processing

### DIFF
--- a/src/components/Effects.tsx
+++ b/src/components/Effects.tsx
@@ -1,7 +1,10 @@
 "use client"
 
-import { EffectComposer, Bloom, Vignette } from "@react-three/postprocessing"
+import { EffectComposer, Bloom, Vignette, ChromaticAberration } from "@react-three/postprocessing"
 import { BlendFunction } from "postprocessing"
+import * as THREE from "three"
+
+const CHROMATIC_OFFSET = new THREE.Vector2(0.0012, 0.0008)
 
 export function Effects() {
   return (
@@ -11,6 +14,12 @@ export function Effects() {
         luminanceThreshold={0.6}
         luminanceSmoothing={0.02}
         mipmapBlur
+      />
+      <ChromaticAberration
+        blendFunction={BlendFunction.NORMAL}
+        offset={CHROMATIC_OFFSET}
+        radialModulation
+        modulationOffset={0.18}
       />
       <Vignette
         offset={0.3}


### PR DESCRIPTION
## Summary
- add a ChromaticAberration pass to the existing post-processing composer
- keep bloom and vignette behavior intact
- use a small radial offset for a subtle cinematic edge effect

Closes #69

## Verification
- npm run lint
- npm run build
- npm test