### PR TITLE
Fix #52: add cinematic HUD visibility toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -453,3 +453,100 @@ html, body {
   text-transform: uppercase;
   animation: fadeInUp 0.14s ease-out;
 }
+
+.mobile-hud-nav {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  :root {
+    --header-height: 58px;
+    --header-x-padding: 10px;
+    --sidebar-width: min(342px, calc(100vw - 18px));
+    --inspector-width: min(320px, calc(100vw - 18px));
+    --terminal-collapsed: 46px;
+  }
+
+  .glass-panel-flat {
+    min-height: var(--header-height);
+  }
+
+  .glass-panel-flat > div:first-child h1 {
+    font-size: 14px !important;
+  }
+
+  .glass-panel-flat > div:nth-child(2) {
+    gap: 6px !important;
+    overflow-x: auto;
+    max-width: calc(100vw - 84px);
+    scrollbar-width: none;
+  }
+
+  .glass-panel-flat > div:nth-child(2)::-webkit-scrollbar {
+    display: none;
+  }
+
+  .glass-panel-flat > div:nth-child(3) {
+    display: none !important;
+  }
+
+  .btn-primary,
+  .btn-ghost {
+    min-height: 32px;
+    padding: 6px 9px;
+    font-size: 10px;
+    white-space: nowrap;
+  }
+
+  .sidebar-left,
+  .sidebar-right {
+    top: calc(var(--header-height) + 8px);
+    left: 9px;
+    right: auto;
+    width: var(--sidebar-width);
+    bottom: 76px;
+    transform: translateY(0);
+  }
+
+  .sidebar-left.collapsed,
+  .sidebar-right.collapsed {
+    transform: translateY(calc(100% + 96px));
+  }
+
+  .sidebar-toggle-left,
+  .sidebar-toggle-right {
+    display: none;
+  }
+
+  .mobile-hud-nav {
+    position: fixed;
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    z-index: 55;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+    padding: 7px;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+    background: rgba(10, 16, 28, 0.92);
+    backdrop-filter: blur(16px);
+  }
+
+  .mobile-hud-nav button {
+    min-height: 36px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+  }
+
+  .mobile-hud-nav button.active {
+    border-color: rgba(56, 189, 248, 0.38);
+    background: rgba(56, 189, 248, 0.14);
+    color: var(--accent-cyan);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import dynamic from "next/dynamic"
-import { AppProvider } from "@/lib/store"
+import { useState } from "react"
+import { AppProvider, useAppState } from "@/lib/store"
 import { Header } from "@/components/Header"
 import { LeftSidebar } from "@/components/LeftSidebar"
 import { RightSidebar } from "@/components/RightSidebar"
@@ -16,30 +17,81 @@ const Scene = dynamic(() => import("@/components/Scene").then((m) => ({ default:
   loading: () => <LoadingSkeleton />,
 })
 
+function MobileHudNav() {
+  const {
+    leftSidebarOpen,
+    rightSidebarOpen,
+    terminalExpanded,
+    toggleLeftSidebar,
+    toggleRightSidebar,
+    toggleTerminal,
+  } = useAppState()
+  const showOnly = (panel: "targets" | "viewport" | "params") => {
+    if (panel === "targets") {
+      if (!leftSidebarOpen) toggleLeftSidebar()
+      if (rightSidebarOpen) toggleRightSidebar()
+      if (terminalExpanded) toggleTerminal()
+    } else if (panel === "viewport") {
+      if (leftSidebarOpen) toggleLeftSidebar()
+      if (rightSidebarOpen) toggleRightSidebar()
+      if (!terminalExpanded) toggleTerminal()
+    } else {
+      if (leftSidebarOpen) toggleLeftSidebar()
+      if (!rightSidebarOpen) toggleRightSidebar()
+      if (terminalExpanded) toggleTerminal()
+    }
+  }
+
+  return (
+    <nav className="mobile-hud-nav" aria-label="Mobile HUD panels">
+      <button className={leftSidebarOpen ? "active" : ""} onClick={() => showOnly("targets")}>
+        <span>Targets</span>
+      </button>
+      <button className={terminalExpanded ? "active" : ""} onClick={() => showOnly("viewport")}>
+        <span>Viewport</span>
+      </button>
+      <button className={rightSidebarOpen ? "active" : ""} onClick={() => showOnly("params")}>
+        <span>Params</span>
+      </button>
+    </nav>
+  )
+}
+
+function HomeShell() {
+  const [hudVisible, setHudVisible] = useState(true)
+
+  return (
+    <main
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+        background: "var(--scene-bg)",
+      }}
+    >
+      {/* Background 3D Space Scene */}
+      <Scene />
+
+      {/* HUD UI Layout Components */}
+      <Header hudVisible={hudVisible} onToggleHud={() => setHudVisible((visible) => !visible)} />
+      {hudVisible && (
+        <>
+          <LeftSidebar />
+          <RightSidebar />
+          <AgentTerminal />
+          <MobileHudNav />
+          <AsteroidCard />
+        </>
+      )}
+    </main>
+  )
+}
+
 export default function Home() {
   return (
     <AppProvider>
-      <main
-        style={{
-          position: "relative",
-          width: "100%",
-          height: "100%",
-          overflow: "hidden",
-          background: "var(--scene-bg)",
-        }}
-      >
-        {/* Background 3D Space Scene */}
-        <Scene />
-
-        {/* HUD UI Layout Components */}
-        <Header />
-        <LeftSidebar />
-        <RightSidebar />
-        <AgentTerminal />
-        
-        {/* Floating Asteroid Inspector */}
-        <AsteroidCard />
-      </main>
+      <HomeShell />
     </AppProvider>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,8 +26,13 @@ function LiveClock() {
   return <span style={{ fontFamily: "var(--font-mono), monospace" }}>{time || "--:--:-- --"}</span>
 }
 
-export function Header() {
-  const { simulationRunning, toggleSimulation, riskLevel, triggerReset, selectedAsteroid } = useAppState()
+interface HeaderProps {
+  hudVisible: boolean
+  onToggleHud: () => void
+}
+
+export function Header({ hudVisible, onToggleHud }: HeaderProps) {
+  const { simulationRunning, toggleSimulation, riskLevel, triggerReset, selectedAsteroid, cinematicMode, toggleCinematicMode } = useAppState()
 
   return (
     <header
@@ -137,6 +142,32 @@ export function Header() {
             Back to Earth
           </button>
         )}
+
+        <button className="btn-ghost" onClick={toggleCinematicMode} aria-pressed={cinematicMode}>
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 7h16M4 17h16M7 4v16M17 4v16" />
+          </svg>
+          {cinematicMode ? "Exit Cinema" : "Cinema"}
+        </button>
+
+        <button className="btn-ghost" onClick={onToggleHud} aria-pressed={!hudVisible}>
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            {hudVisible ? (
+              <>
+                <path d="M3 3l18 18" />
+                <path d="M10.6 10.6A2 2 0 0 0 12 14a2 2 0 0 0 1.4-.6" />
+                <path d="M9.9 4.2A10.6 10.6 0 0 1 12 4c5 0 9 5 9 8a8.7 8.7 0 0 1-2.1 3.9" />
+                <path d="M6.1 6.1C4.2 7.4 3 9.6 3 12c0 3 4 8 9 8 1.4 0 2.7-.4 3.9-1" />
+              </>
+            ) : (
+              <>
+                <path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z" />
+                <circle cx="12" cy="12" r="3" />
+              </>
+            )}
+          </svg>
+          HUD
+        </button>
       </div>
 
       {/* Right: Clock */}

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from "react"
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react"
 import type { AsteroidData } from "./types"
 
 export interface ConjunctionAlert {
@@ -101,6 +101,15 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [cameraFov, setCameraFov] = useState(75)
   const [autoRotate, setAutoRotate] = useState(false)
   const [bloomIntensity, setBloomIntensity] = useState(1.0)
+
+  useEffect(() => {
+    if (window.innerWidth >= 768) return
+    const frame = requestAnimationFrame(() => {
+      setLeftSidebarOpen(false)
+      setRightSidebarOpen(false)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [])
 
   const selectAsteroid = useCallback((a: AsteroidData | null) => setSelectedAsteroid(a), [])
 


### PR DESCRIPTION
## Summary
- add header controls for Cinematic Mode and HUD visibility
- keep the scene mounted while hiding HUD overlays
- add a compact mobile HUD panel nav with sidebars collapsed by default on small screens

Closes #52

## Verification
- git diff --check
- npm run build