### PR TITLE
Fix #62/#63/#64/#72: enhance Earth and scene lighting

### DIFF
--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,19 +1,99 @@
 "use client"
 
 import { useRef, useCallback, useEffect, useMemo } from "react"
-import { Canvas } from "@react-three/fiber"
+import { Canvas, useFrame } from "@react-three/fiber"
 import { Stats, Stars } from "@react-three/drei"
 import * as THREE from "three"
 
 import { Earth } from "./earth/Earth"
 import { CloudLayer } from "./earth/CloudLayer"
 import { Atmosphere } from "./earth/Atmosphere"
-import { AsteroidField, trackedPosition } from "./AsteroidField"
+import { AsteroidField } from "./AsteroidField"
 import { SatelliteSystem } from "./SatelliteSystem"
 import { CameraController } from "./CameraController"
 import { Effects } from "./Effects"
 import { useAppState } from "@/lib/store"
 import type { AsteroidData } from "@/lib/types"
+
+function createFlareTexture() {
+  const canvas = document.createElement("canvas")
+  canvas.width = 128
+  canvas.height = 128
+  const ctx = canvas.getContext("2d")!
+  const gradient = ctx.createRadialGradient(64, 64, 0, 64, 64, 64)
+  gradient.addColorStop(0, "rgba(255,255,255,0.95)")
+  gradient.addColorStop(0.25, "rgba(255,220,140,0.5)")
+  gradient.addColorStop(0.55, "rgba(56,189,248,0.18)")
+  gradient.addColorStop(1, "rgba(56,189,248,0)")
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, 128, 128)
+  return new THREE.CanvasTexture(canvas)
+}
+
+function seededUnit(seed: number) {
+  const x = Math.sin(seed * 12.9898) * 43758.5453
+  return x - Math.floor(x)
+}
+
+function DynamicStarfield() {
+  const ref = useRef<THREE.Points>(null)
+  const positions = useMemo(() => {
+    const values = new Float32Array(1800 * 3)
+    for (let i = 0; i < 1800; i++) {
+      const radius = 35 + seededUnit(i * 3 + 1) * 70
+      const theta = seededUnit(i * 3 + 2) * Math.PI * 2
+      const phi = Math.acos(2 * seededUnit(i * 3 + 3) - 1)
+      values[i * 3] = radius * Math.sin(phi) * Math.cos(theta)
+      values[i * 3 + 1] = radius * Math.cos(phi)
+      values[i * 3 + 2] = radius * Math.sin(phi) * Math.sin(theta)
+    }
+    return values
+  }, [])
+
+  useFrame((_, delta) => {
+    if (ref.current) ref.current.rotation.y += delta * 0.003
+  })
+
+  return (
+    <points ref={ref}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+      </bufferGeometry>
+      <pointsMaterial color="#d8f3ff" size={0.035} sizeAttenuation transparent opacity={0.82} />
+    </points>
+  )
+}
+
+function SunRig({ sunDirection }: { sunDirection: THREE.Vector3 }) {
+  const lightRef = useRef<THREE.DirectionalLight>(null)
+  const flareRef = useRef<THREE.Group>(null)
+  const flareTexture = useMemo(() => createFlareTexture(), [])
+
+  useFrame((state) => {
+    const t = state.clock.getElapsedTime() * 0.045
+    sunDirection.set(Math.cos(t) * 5, 2.6 + Math.sin(t * 0.5) * 0.7, Math.sin(t) * 5).normalize()
+    if (lightRef.current) {
+      lightRef.current.position.copy(sunDirection).multiplyScalar(6)
+    }
+    if (flareRef.current) {
+      flareRef.current.position.copy(sunDirection).multiplyScalar(6)
+    }
+  })
+
+  return (
+    <>
+      <directionalLight ref={lightRef} position={[5, 3, 5]} intensity={2} />
+      <group ref={flareRef} position={[4.7, 2.8, 4.7]}>
+        <sprite scale={[1.25, 1.25, 1]}>
+          <spriteMaterial map={flareTexture} color="#fff2c4" transparent opacity={0.45} depthWrite={false} />
+        </sprite>
+        <sprite position={[-1.8, -1.1, -1.8]} scale={[0.34, 0.34, 1]}>
+          <spriteMaterial map={flareTexture} color="#38bdf8" transparent opacity={0.2} depthWrite={false} />
+        </sprite>
+      </group>
+    </>
+  )
+}
 
 function SceneContent() {
   const sunDirection = useMemo(() => new THREE.Vector3(5, 3, 5).normalize(), [])
@@ -39,8 +119,9 @@ function SceneContent() {
       <color attach="background" args={["#000008"]} />
       <Stats />
       <ambientLight intensity={0.5} />
-      <directionalLight position={[5, 3, 5]} intensity={2} />
+      <SunRig sunDirection={sunDirection} />
       <Stars radius={100} depth={50} count={3000} factor={4} saturation={0} fade speed={1} />
+      <DynamicStarfield />
 
       <Earth sunDirection={sunDirection} />
       <CloudLayer sunDirection={sunDirection} />

--- a/src/components/earth/Atmosphere.tsx
+++ b/src/components/earth/Atmosphere.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useRef, useEffect } from "react"
+import { useMemo, useRef } from "react"
+import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
 const vertexShader = `
@@ -48,19 +49,19 @@ interface AtmosphereProps {
 
 export function Atmosphere({ sunDirection }: AtmosphereProps) {
   const meshRef = useRef<THREE.Mesh>(null)
-  const uniformsRef = useRef({
+  const uniforms = useMemo(() => ({
     sunDirection: { value: sunDirection.clone() },
-  })
+  }), [sunDirection])
 
-  useEffect(() => {
-    uniformsRef.current.sunDirection.value.copy(sunDirection)
-  }, [sunDirection])
+  useFrame(() => {
+    uniforms.sunDirection.value.copy(sunDirection)
+  })
 
   return (
     <mesh ref={meshRef}>
       <sphereGeometry args={[2.0, 64, 64]} />
       <shaderMaterial
-        uniforms={uniformsRef.current}
+        uniforms={uniforms}
         vertexShader={vertexShader}
         fragmentShader={fragmentShader}
         transparent

--- a/src/components/earth/CloudLayer.tsx
+++ b/src/components/earth/CloudLayer.tsx
@@ -67,20 +67,19 @@ export function CloudLayer({ sunDirection }: CloudLayerProps) {
   const meshRef = useRef<THREE.Mesh>(null)
 
   const uniforms = useMemo(() => ({
-    cloudTexture: { value: null as unknown as THREE.Texture },
+    cloudTexture: { value: new THREE.CanvasTexture(createProceduralCloudTexture()) },
     sunDirection: { value: sunDirection.clone() },
   }), [sunDirection])
 
   useEffect(() => {
-    const tex = new THREE.CanvasTexture(createProceduralCloudTexture())
-    uniforms.cloudTexture.value = tex
-    uniforms.sunDirection.value.copy(sunDirection)
-  }, [sunDirection, uniforms])
+    return () => uniforms.cloudTexture.value.dispose()
+  }, [uniforms])
 
   useFrame((_, delta) => {
     if (meshRef.current) {
       meshRef.current.rotation.y += delta * 0.06
     }
+    uniforms.sunDirection.value.copy(sunDirection)
   })
 
   return (

--- a/src/components/earth/Earth.tsx
+++ b/src/components/earth/Earth.tsx
@@ -75,44 +75,37 @@ interface EarthProps {
   sunDirection: THREE.Vector3
 }
 
-function makeDefaultTexture() {
-  const canvas = document.createElement("canvas")
-  canvas.width = 2
-  canvas.height = 2
-  const ctx = canvas.getContext("2d")!
-  ctx.fillStyle = "#4488cc"
-  ctx.fillRect(0, 0, 2, 2)
-  return new THREE.CanvasTexture(canvas)
-}
-
 export function Earth({ sunDirection }: EarthProps) {
   const meshRef = useRef<THREE.Mesh>(null)
 
-  const uniforms = useMemo(() => ({
-    dayTexture: { value: makeDefaultTexture() as THREE.Texture },
-    nightTexture: { value: makeDefaultTexture() as THREE.Texture },
-    specularTexture: { value: makeDefaultTexture() as THREE.Texture },
-    cloudShadowTexture: { value: makeDefaultTexture() as THREE.Texture },
-    sunDirection: { value: sunDirection.clone() },
-  }), [sunDirection])
-
-  useEffect(() => {
+  const uniforms = useMemo(() => {
     const day = new THREE.CanvasTexture(createProceduralEarthTexture())
     const night = new THREE.CanvasTexture(createProceduralNightTexture())
     const spec = new THREE.CanvasTexture(createProceduralSpecularTexture())
     const cloud = new THREE.CanvasTexture(createProceduralCloudTexture())
-    uniforms.dayTexture.value = day
-    uniforms.nightTexture.value = night
-    uniforms.specularTexture.value = spec
-    uniforms.cloudShadowTexture.value = cloud
-    // sunDirection is constant — set once
-    uniforms.sunDirection.value.copy(sunDirection)
-  }, [sunDirection, uniforms])
+    return {
+      dayTexture: { value: day },
+      nightTexture: { value: night },
+      specularTexture: { value: spec },
+      cloudShadowTexture: { value: cloud },
+      sunDirection: { value: sunDirection.clone() },
+    }
+  }, [sunDirection])
+
+  useEffect(() => {
+    return () => {
+      uniforms.dayTexture.value.dispose()
+      uniforms.nightTexture.value.dispose()
+      uniforms.specularTexture.value.dispose()
+      uniforms.cloudShadowTexture.value.dispose()
+    }
+  }, [uniforms])
 
   useFrame((_, delta) => {
     if (meshRef.current) {
       meshRef.current.rotation.y += delta * 0.05
     }
+    uniforms.sunDirection.value.copy(sunDirection)
   })
 
   return (

--- a/src/components/earth/textures.ts
+++ b/src/components/earth/textures.ts
@@ -65,12 +65,6 @@ export function createProceduralEarthTexture(): HTMLCanvasElement {
     ctx.fill()
 
     // Add some terrain variation
-    const bound = ctx.getImageData(
-      Math.max(0, cx - 0.12 * w),
-      Math.max(0, cy - 0.12 * w),
-      Math.min(w, 0.24 * w),
-      Math.min(h, 0.24 * w)
-    )
     for (let i = 0; i < 80; i++) {
       const tx = cx + (Math.random() - 0.5) * 0.2 * w
       const ty = cy + (Math.random() - 0.5) * 0.2 * w


### PR DESCRIPTION
## Summary
- animate the scene sun vector to drive a visible Earth day/night cycle
- keep Earth, clouds, and atmosphere shader uniforms synchronized per frame
- add sun lens flare sprites and a deterministic dynamic starfield
- clean up shader texture initialization to satisfy React Compiler lint rules

Closes #62
Closes #63
Closes #64
Closes #72

## Verification
- npm run lint
- npm run build