### PR TITLE
[Fix] Implement Error Boundaries for 3D Canvas (Issue 105)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "16.2.7",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-error-boundary": "^6.1.2",
         "three": "^0.184.0"
       },
       "devDependencies": {
@@ -5923,6 +5924,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "16.2.7",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-error-boundary": "^6.1.2",
     "three": "^0.184.0"
   },
   "devDependencies": {

--- a/src/components/CanvasErrorBoundary.tsx
+++ b/src/components/CanvasErrorBoundary.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { ErrorBoundary, FallbackProps } from "react-error-boundary"
+
+function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const errorMessage = error instanceof Error ? error.message : String(error)
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center bg-black/90 p-6 text-red-500 backdrop-blur-md">
+      <h2 className="mb-4 text-2xl font-bold uppercase tracking-wider text-red-400">
+        System Failure
+      </h2>
+      <div className="max-w-xl overflow-auto rounded border border-red-500/30 bg-red-950/20 p-4 font-mono text-sm">
+        <p className="mb-2 font-bold">Error in 3D Canvas:</p>
+        <p className="text-red-300">{errorMessage}</p>
+      </div>
+      <button
+        onClick={resetErrorBoundary}
+        className="mt-6 rounded border border-red-500/50 bg-red-950/50 px-6 py-2 uppercase tracking-widest text-red-400 transition-colors hover:bg-red-500 hover:text-white"
+      >
+        Reboot System
+      </button>
+    </div>
+  )
+}
+
+export function CanvasErrorBoundary({ children }: { children: React.ReactNode }) {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -12,6 +12,7 @@ import { AsteroidField, trackedPosition } from "./AsteroidField"
 import { SatelliteSystem } from "./SatelliteSystem"
 import { CameraController } from "./CameraController"
 import { Effects } from "./Effects"
+import { CanvasErrorBoundary } from "./CanvasErrorBoundary"
 import { useAppState } from "@/lib/store"
 
 function SceneContent() {
@@ -55,12 +56,14 @@ function SceneContent() {
 export function Scene() {
   return (
     <div className="fixed inset-0 z-0">
-      <Canvas
-        camera={{ position: [0, 0, 6], fov: 45, near: 0.1, far: 100 }}
-        gl={{ antialias: true, alpha: false }}
-      >
-        <SceneContent />
-      </Canvas>
+      <CanvasErrorBoundary>
+        <Canvas
+          camera={{ position: [0, 0, 6], fov: 45, near: 0.1, far: 100 }}
+          gl={{ antialias: true, alpha: false }}
+        >
+          <SceneContent />
+        </Canvas>
+      </CanvasErrorBoundary>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #105. Added CanvasErrorBoundary to catch WebGL and R3F rendering crashes gracefully.