### PR TITLE
[Fix] Optimize Next.js font loading (Issue 106)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,11 +5,13 @@ import "./globals.css"
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  display: "swap",
 })
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains-mono",
   subsets: ["latin"],
+  display: "swap",
 })
 
 export const metadata: Metadata = {


### PR DESCRIPTION
Fixes #106. Configured 'display: swap' for both Geist and JetBrains Mono fonts to improve LCP and prevent layout shifts.