### PR TITLE
[Fix] Ensure sufficient color contrast in text panels (Issue 111)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,9 +15,9 @@
   --border-glow: rgba(255, 255, 255, 0.1);
   --border-focus: rgba(56, 189, 248, 0.4);
   --text-primary: rgba(255, 255, 255, 0.92);
-  --text-secondary: rgba(255, 255, 255, 0.6);
-  --text-muted: rgba(255, 255, 255, 0.35);
-  --text-label: rgba(255, 255, 255, 0.45);
+  --text-secondary: rgba(255, 255, 255, 0.75);
+  --text-muted: rgba(255, 255, 255, 0.55);
+  --text-label: rgba(255, 255, 255, 0.65);
   --accent-cyan: #38bdf8;
   --accent-cyan-dim: rgba(56, 189, 248, 0.15);
   --accent-green: #34d399;


### PR DESCRIPTION
Fixes #111. Increased opacity of text-secondary, text-muted, and text-label variables to meet WCAG AA contrast ratio standards (4.5:1 minimum).