### PR TITLE
[Fix] Provide text alternatives for WebGL canvas (Issue 112)

### DIFF
--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -54,7 +54,11 @@ function SceneContent() {
 
 export function Scene() {
   return (
-    <div className="fixed inset-0 z-0">
+    <div 
+      className="fixed inset-0 z-0" 
+      role="region" 
+      aria-label="Interactive 3D simulation of Earth, satellites, and asteroids in real-time"
+    >
       <Canvas
         camera={{ position: [0, 0, 6], fov: 45, near: 0.1, far: 100 }}
         gl={{ antialias: true, alpha: false }}


### PR DESCRIPTION
Fixes #112. Added aria-label and role='region' to the wrapper div of the WebGL canvas so screen readers can describe the 3D scene.