### PR TITLE
[Feature] Add a 'reduce motion' preference toggle (Issue 114)

### DIFF
--- a/src/components/CameraController.tsx
+++ b/src/components/CameraController.tsx
@@ -13,7 +13,7 @@ const _lookTarget = new THREE.Vector3()
 
 export function CameraController() {
   const { camera } = useThree()
-  const { selectedAsteroid, resetCamera, clearReset } = useAppState()
+  const { selectedAsteroid, resetCamera, clearReset, reduceMotion } = useAppState()
   const targetPos = useRef(EARTH_POSITION.clone())
   const targetLook = useRef(EARTH_TARGET.clone())
   const hasSelection = useRef(false)
@@ -43,7 +43,11 @@ export function CameraController() {
       }
     }
 
-    camera.position.lerp(targetPos.current, 3 * delta)
+    if (reduceMotion) {
+      camera.position.copy(targetPos.current)
+    } else {
+      camera.position.lerp(targetPos.current, 3 * delta)
+    }
     _lookTarget.copy(targetLook.current)
     camera.lookAt(_lookTarget)
   })

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ function LiveClock() {
 }
 
 export function Header() {
-  const { simulationRunning, toggleSimulation, riskLevel, triggerReset, selectedAsteroid } = useAppState()
+  const { simulationRunning, toggleSimulation, riskLevel, triggerReset, selectedAsteroid, reduceMotion, toggleReduceMotion } = useAppState()
 
   return (
     <header
@@ -137,6 +137,20 @@ export function Header() {
             Back to Earth
           </button>
         )}
+
+        <button 
+          className="btn-ghost" 
+          onClick={toggleReduceMotion}
+          aria-pressed={reduceMotion}
+          title={reduceMotion ? "Enable Motion" : "Reduce Motion"}
+        >
+          {reduceMotion ? (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
+          )}
+          {reduceMotion ? "Motion: Reduced" : "Motion: Full"}
+        </button>
       </div>
 
       {/* Right: Clock */}

--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -58,6 +58,8 @@ interface AppState {
   conjunctions: ConjunctionAlert[]
   addConjunctionAlert: (alert: Omit<ConjunctionAlert, "id">) => void
   clearConjunctions: () => void
+  reduceMotion: boolean
+  toggleReduceMotion: () => void
 }
 
 const AppContext = createContext<AppState | null>(null)
@@ -71,6 +73,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [resetCamera, setResetCamera] = useState(false)
   const [simulationRunning, setSimulationRunning] = useState(true)
   const [riskLevel, setRiskLevel] = useState<"HIGH" | "MEDIUM" | "LOW">("LOW")
+  const [reduceMotion, setReduceMotion] = useState(false)
 
   const [leftSidebarOpen, setLeftSidebarOpen] = useState(true)
   const [rightSidebarOpen, setRightSidebarOpen] = useState(true)
@@ -109,6 +112,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const toggleLeftSidebar = useCallback(() => setLeftSidebarOpen((p) => !p), [])
   const toggleRightSidebar = useCallback(() => setRightSidebarOpen((p) => !p), [])
   const toggleTerminal = useCallback(() => setTerminalExpanded((p) => !p), [])
+  const toggleReduceMotion = useCallback(() => setReduceMotion((p) => !p), [])
 
   const registerAsteroidData = useCallback((data: AsteroidData[]) => {
     asteroidDataRef.current = data
@@ -210,6 +214,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         conjunctions,
         addConjunctionAlert,
         clearConjunctions,
+        reduceMotion,
+        toggleReduceMotion,
       }}
     >
       {children}


### PR DESCRIPTION
Fixes #114. Added a preference toggle in the Header to reduce motion. When active, 3D camera animations (lerp) instantly snap to the target instead of transitioning smoothly.