### PR TITLE
[Fix] Implement semantic HTML in the layout (Issue 115)

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -96,7 +96,7 @@ export function AgentTerminal() {
   }, [logs, terminalExpanded])
 
   return (
-    <div
+    <footer
       className="glass-panel-flat"
       style={{
         position: "fixed",
@@ -211,6 +211,6 @@ export function AgentTerminal() {
           </span>
         </div>
       )}
-    </div>
+    </footer>
   )
 }

--- a/src/components/AsteroidCard.tsx
+++ b/src/components/AsteroidCard.tsx
@@ -16,8 +16,9 @@ export function AsteroidCard() {
   const isClaimed = claimedAsteroids.has(selectedAsteroid.id)
 
   return (
-    <div
+    <section
       className="glass-panel animate-fade-in-left"
+      aria-labelledby="asteroid-card-title"
       style={{
         position: "fixed",
         top: "calc(var(--header-height) + 16px)",
@@ -52,17 +53,19 @@ export function AsteroidCard() {
                 : "0 0 6px var(--accent-cyan)",
             }}
           />
-          <span
+          <h2
+            id="asteroid-card-title"
             style={{
               fontSize: 11,
               fontWeight: 700,
               letterSpacing: "0.08em",
               textTransform: "uppercase",
               color: "var(--text-primary)",
+              margin: 0,
             }}
           >
             Inspector: {selectedAsteroid.name}
-          </span>
+          </h2>
         </div>
         <button
           className="btn-ghost"
@@ -163,6 +166,6 @@ export function AsteroidCard() {
           </button>
         </div>
       </div>
-    </div>
+    </section>
   )
 }


### PR DESCRIPTION
Fixes #115. Refactored structural elements to use semantic HTML: AgentTerminal is now a <footer>, and AsteroidCard is a <section> with an aria-labelledby link to its title. Left and Right sidebars were already using <aside>.