### PR TITLE
[Fix] Audit ARIA roles across custom UI elements (Issue 119)

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -169,6 +169,8 @@ export function AgentTerminal() {
       {terminalExpanded && (
         <div
           ref={scrollRef}
+          role="log"
+          aria-live="polite"
           style={{
             flex: 1,
             overflowY: "auto",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -101,12 +101,12 @@ export function Header() {
           {simulationRunning ? "Pause Simulation" : "Run Simulation"}
         </button>
 
-        <div className={`badge ${riskLevel === "HIGH" ? "badge-high" : riskLevel === "MEDIUM" ? "badge-medium" : "badge-low"}`}>
+        <div role="status" className={`badge ${riskLevel === "HIGH" ? "badge-high" : riskLevel === "MEDIUM" ? "badge-medium" : "badge-low"}`}>
           Risk: {riskLevel}
         </div>
 
         {/* Connection indicator */}
-        <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+        <div role="status" style={{ display: "flex", alignItems: "center", gap: 5 }}>
           <div
             style={{
               width: 6,

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -134,10 +134,12 @@ export function LeftSidebar() {
               <label style={{ fontSize: 10, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--text-muted)", marginBottom: 6, display: "block" }}>
                 Filter Catalog
               </label>
-              <div style={{ display: "flex", background: "var(--bg-input)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-sm)", padding: 2 }}>
+              <div role="tablist" style={{ display: "flex", background: "var(--bg-input)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius-sm)", padding: 2 }}>
                 {(["ALL", "ASTEROIDS", "DEBRIS"] as const).map((tab) => (
                   <button
                     key={tab}
+                    role="tab"
+                    aria-selected={filterType === tab}
                     onClick={() => setFilterType(tab)}
                     style={{
                       flex: 1,


### PR DESCRIPTION
Fixes #119. Audited custom UI elements for correct ARIA roles: added role='tablist', role='tab' and aria-selected to custom tabs in LeftSidebar, role='status' to Risk level and Connection indicators in Header, and role='log' + aria-live='polite' to the AgentTerminal.