### PR TITLE
[SEO] Add canonical URLs (Issue 126)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,13 @@ export const metadata: Metadata = {
   title: "AstroDex — Interactive 3D Asteroid Explorer",
   description:
     "Explore 600+ asteroids orbiting Earth in real-time 3D. Track conjunctions, inspect orbital parameters, and claim discoveries in this cinematic space mission control.",
+  keywords: ["Asteroid tracker", "3D Space", "Orbital mechanics", "Near-Earth objects", "WebGL space simulation", "Astrodex", "Space mission control"],
+  authors: [{ name: "AstroDex Team" }],
+  creator: "AstroDex",
+  publisher: "AstroDex",
+  alternates: {
+    canonical: 'https://astrodex.app',
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Fixes #126. Added canonical URLs to the root layout's metadata to prevent duplicate content issues for search engines.