### PR TITLE
[Accessibility] Add descriptive alt text to all UI images (Issue 128)

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -134,7 +134,7 @@ export function AgentTerminal() {
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg role="img" aria-label="Terminal prompt icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="4 17 10 11 4 5" />
             <line x1="12" y1="19" x2="20" y2="19" />
           </svg>
@@ -148,6 +148,8 @@ export function AgentTerminal() {
           )}
         </div>
         <svg
+          role="img"
+          aria-label="Send message icon"
           width="14"
           height="14"
           viewBox="0 0 24 24"

--- a/src/components/AsteroidCard.tsx
+++ b/src/components/AsteroidCard.tsx
@@ -70,6 +70,8 @@ export function AsteroidCard() {
           style={{ padding: 4, border: "none" }}
         >
           <svg
+            role="img"
+            aria-label="Close icon"
             width="14"
             height="14"
             viewBox="0 0 24 24"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -80,6 +80,8 @@ export function Header() {
       <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
         <button className="btn-primary" onClick={toggleSimulation}>
           <svg
+            role="img"
+            aria-label={simulationRunning ? "Pause icon" : "Play icon"}
             width="12"
             height="12"
             viewBox="0 0 24 24"
@@ -131,7 +133,7 @@ export function Header() {
 
         {selectedAsteroid && (
           <button className="btn-ghost" onClick={triggerReset}>
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg role="img" aria-label="Back icon" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M19 12H5M12 5l-7 7 7 7" />
             </svg>
             Back to Earth

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -76,7 +76,7 @@ export function LeftSidebar() {
           onClick={toggleLeftSidebar}
           title="Show Target Panel"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg role="img" aria-label="Search icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M9 18l6-6-6-6" />
           </svg>
         </button>
@@ -103,7 +103,7 @@ export function LeftSidebar() {
             }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg role="img" aria-label="Active indicator icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-cyan)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="3" />
                 <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
               </svg>
@@ -112,7 +112,7 @@ export function LeftSidebar() {
               </span>
             </div>
             <button className="btn-ghost" onClick={toggleLeftSidebar} style={{ padding: 4, border: "none" }}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg role="img" aria-label="Target icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M15 18l-6-6 6-6" />
               </svg>
             </button>
@@ -175,7 +175,7 @@ export function LeftSidebar() {
                   style={{ flex: 1 }}
                 />
                 <button className="btn-ghost" onClick={handleSearch} style={{ whiteSpace: "nowrap" }}>
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <svg role="img" aria-label="Clear target icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                     <circle cx="11" cy="11" r="8" />
                     <path d="M21 21l-4.35-4.35" />
                   </svg>

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -105,7 +105,7 @@ export function RightSidebar() {
           onClick={toggleRightSidebar}
           title="Show Constraints Panel"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg role="img" aria-label="Time travel reverse icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </button>
@@ -126,14 +126,14 @@ export function RightSidebar() {
           >
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <button className="btn-ghost" onClick={toggleRightSidebar} style={{ padding: 4, border: "none" }}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg role="img" aria-label="Time travel forward icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M9 18l6-6-6-6" />
                 </svg>
               </button>
               <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", color: "var(--text-primary)" }}>
                 Constraints
               </span>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg role="img" aria-label="Reset time icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
               </svg>
             </div>
@@ -343,7 +343,7 @@ export function RightSidebar() {
                   opacity: satAltitude >= LEO_LIMITS.CEILING ? 0.4 : 1,
                 }}
               >
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <svg role="img" aria-label="Deploy satellite icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M12 19V5M5 12l7-7 7 7" />
                 </svg>
                 Boost Burn (+50 km)


### PR DESCRIPTION
Fixes #128. Added role='img' and aria-label attributes to all SVG icons across the UI to provide descriptive alternative text for screen readers, improving overall accessibility.