### PR TITLE
[Performance] Optimize LCP (Largest Contentful Paint) (Issue 129)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,11 @@ import { AsteroidCard } from "@/components/AsteroidCard"
 
 const Scene = dynamic(() => import("@/components/Scene").then((m) => ({ default: m.Scene })), {
   ssr: false,
+  loading: () => (
+    <div style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center", background: "#000005", color: "var(--accent-cyan)", fontFamily: "var(--font-jetbrains-mono), monospace", fontSize: "14px" }}>
+      Initializing WebGL context...
+    </div>
+  ),
 })
 
 export default function Home() {


### PR DESCRIPTION
Fixes #129. Optimized LCP by adding a fast-rendering loading skeleton to the dynamically imported Scene component, giving the browser an immediate contentful element to paint while WebGL initializes.