### PR TITLE
docs: document asteroid data registration state sync

### DIFF
--- a/src/lib/store.tsx
+++ b/src/lib/store.tsx
@@ -136,6 +136,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const toggleTerminal = useCallback(() => setTerminalExpanded((p) => !p), [])
 
   const registerAsteroidData = useCallback((data: AsteroidData[]) => {
+    // Update the ref immediately so searchAsteroidById can access the latest
+    // asteroid data without waiting for the asynchronous React state update.
     asteroidDataRef.current = data
     setAsteroidCatalog(data)
   }, [])


### PR DESCRIPTION
## 🔗 Related Issue
Closes #182

---

## 📝 Description of Changes

Added inline documentation to the asteroid data registration callback in `src/lib/store.tsx`.

The comment explains why `asteroidDataRef.current` is updated immediately before the React state update, ensuring that `searchAsteroidById` can access the latest asteroid data without waiting for the asynchronous state update.

No application logic or functionality was changed.

---

## 🏷️ Proposed Labels
- [ ] UI/UX
- [x] Documentation
- [ ] CI/CD
- [ ] Backend Logic
- [ ] Anything else

---

## 📂 Core Files Changed

- `src/lib/store.tsx` — Added inline documentation for `registerAsteroidData`.

---

## 📸 Verification & Screenshots
- **UI/UX (User Interface / User Experience - how it looks and feels):**
  
  Not applicable — documentation-only change.

- **CI/CD (Continuous Integration / Continuous Deployment - the automated build/test pipeline):**

  `npm run build` passed successfully.

---

## 🤖 AI Assistance Declaration
**Did you use an AI tool to write or assist with this code OR Pull Request?**
- [x] Yes
- [ ] No

> **⚠️ IF YOU CHECKED "YES", YOU MUST ANSWER THE FOLLOWING:**
* **Which AI Model did you use?**: GPT-5.5
* **Which Platform/Tool?**: ChatGPT web chat
* **What exactly did the AI do?**: Helped modify the inline documentation comment.
* **What exactly did YOU do?**: Reviewed the code, made the change, ran the production build, committed the changes, and pushed the branch.
* **What is the advantage of using this AI approach here?**: It helped improve the clarity of the documentation while keeping the implementation unchanged.
---

## ⚠️ Reviewer Notes

This is a documentation-only change. No application logic or functionality was modified.

---

## ✅ The "I Swear I Didn't Break Anything" Pledge
- [x] I have thoroughly tested these changes in my own local branch.
- [x] I verified multiple times that this code compiles into a standalone build and does not break existing production features.