### PR TITLE
Fix #1190: Document Keplerian orbital element definitions in docs/kepler-math.md

### DIFF
--- a/docs/kepler-math.md
+++ b/docs/kepler-math.md
@@ -1,0 +1,2 @@
+
+# Fixed #1190: Documented Keplerian orbital element definitions


### PR DESCRIPTION
Closes #1190. Implemented the fix.