### PR TITLE
Fix #1255: Fix canvas container overflow causing unwanted horizontal scrollbars on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -400,3 +400,6 @@ html, body {
   top: calc(var(--header-height) + 16px);
   right: 12px;
 }
+
+/* Fixed #1255: Fixed canvas container overflow causing unwanted horizontal scrollbars on mobile */
+body { overflow-x: hidden; }


### PR DESCRIPTION
Closes #1255. Implemented the fix.