### PR TITLE
fix: add aria label to header profile link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -171,7 +171,12 @@ export function Header() {
             <LiveClock />
           </span>
         </div>
-        <Link href="/profile" className="btn-ghost" style={{ padding: "6px 12px", textDecoration: "none", color: "var(--accent-cyan)", border: "1px solid rgba(56, 189, 248, 0.4)" }}>
+        <Link
+          href="/profile"
+          className="btn-ghost"
+          style={{ padding: "6px 12px", textDecoration: "none", color: "var(--accent-cyan)", border: "1px solid rgba(56, 189, 248, 0.4)" }}
+          aria-label="Open Commander Profile page"
+        >
           Commander Profile
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- add an explicit aria-label to the Header Commander Profile navigation link
- keep the existing visual styling and route behavior unchanged

## Validation
- Reviewed the GitHub compare diff for the single touched Header link.
- Local lint/build not run because this workspace currently has very low free disk space, so I avoided installing/cloning dependencies during the heartbeat run.

Closes #2081