### PR TITLE
fix: improve toast text contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,7 @@
   --text-secondary: rgba(255, 255, 255, 0.6);
   --text-muted: rgba(255, 255, 255, 0.35);
   --text-label: rgba(255, 255, 255, 0.45);
+  --toast-text-high-contrast: #f8fafc;
   --accent-cyan: #38bdf8;
   --accent-cyan-dim: rgba(56, 189, 248, 0.15);
   --accent-green: #34d399;

--- a/src/components/Toasts.test.tsx
+++ b/src/components/Toasts.test.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Toasts } from "@/components/Toasts"
+import { AppProvider, useAppState } from "@/lib/store"
+
+function ToastSeeder() {
+  const { addToast } = useAppState()
+
+  useEffect(() => {
+    addToast("Success toast message", "success")
+    addToast("Error toast message", "error")
+    addToast("Info toast message", "info")
+  }, [addToast])
+
+  return null
+}
+
+describe("Toasts", () => {
+  it("uses high-contrast message text for every toast type", () => {
+    render(
+      <AppProvider>
+        <ToastSeeder />
+        <Toasts />
+      </AppProvider>
+    )
+
+    expect(screen.getByText("Success toast message")).toHaveStyle({
+      color: "var(--toast-text-high-contrast)",
+    })
+    expect(screen.getByText("Error toast message")).toHaveStyle({
+      color: "var(--toast-text-high-contrast)",
+    })
+    expect(screen.getByText("Info toast message")).toHaveStyle({
+      color: "var(--toast-text-high-contrast)",
+    })
+  })
+})

--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -58,14 +58,20 @@ export function Toasts() {
                 <line x1="12" y1="17" x2="12.01" y2="17" />
               </svg>
             )}
-            <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-primary)" }}>
+            <span style={{ fontSize: 13, fontWeight: 500, color: "var(--toast-text-high-contrast)" }}>
               {toast.message}
             </span>
           </div>
           <button
             className="btn-ghost"
+            aria-label="Dismiss notification"
             onClick={() => removeToast(toast.id)}
-            style={{ padding: 4, border: "none", marginLeft: 16 }}
+            style={{
+              padding: 4,
+              border: "none",
+              marginLeft: 16,
+              color: "var(--toast-text-high-contrast)",
+            }}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" />


### PR DESCRIPTION
## Summary
- Add a high-contrast toast text token using `#f8fafc` for the dark translucent toast surface.
- Apply the token to toast message text across success, error, and info notifications.
- Keep the dismiss control readable and add an accessible label for the toast close button.
- Add a focused component regression test covering all toast types.

Closes #2083

## Testing
- `npm run test -- --run src/components/Toasts.test.tsx` - passed
- `npm run typecheck` - passed
- `npm run lint -- src/components/Toasts.tsx src/components/Toasts.test.tsx` - passed
- `npm run build` - passed
- `git diff --check -- src/components/Toasts.tsx src/components/Toasts.test.tsx src/app/globals.css` - passed

## Notes
- `npm run lint` still reports pre-existing repository-wide lint errors outside this change, including existing `no-explicit-any`, React compiler, and unused-variable findings in unrelated files.
- No UI layout changes were made, so screenshots are not required for this text-contrast-only fix.