### PR TITLE
fix: announce simulation speed changes

### DIFF
--- a/src/__tests__/RightSidebar.test.tsx
+++ b/src/__tests__/RightSidebar.test.tsx
@@ -10,9 +10,16 @@ vi.mock("../lib/store", () => ({
 }))
 
 describe("RightSidebar Settings Modal", () => {
+  const setTimeScaleMultiplier = vi.fn()
+
   const mockAppState = {
     rightSidebarOpen: true,
     toggleRightSidebar: vi.fn(),
+    toggleSimulation: vi.fn(),
+    simulationRunning: true,
+    timeScaleMultiplier: 1,
+    setTimeScaleMultiplier,
+    triggerReset: vi.fn(),
     satAltitude: 400,
     satInclination: 51.6,
     satRaan: 0,
@@ -36,8 +43,17 @@ describe("RightSidebar Settings Modal", () => {
 
   it("calls boostBurn when boost button clicked", () => {
     render(<RightSidebar />)
-    const boostBtn = screen.getByText(/Execute Prograde/i)
+    const boostBtn = screen.getByText(/Boost Burn/i)
     fireEvent.click(boostBtn)
     expect(mockAppState.boostBurn).toHaveBeenCalled()
+  })
+
+  it("announces simulation speed changes in a polite live region", () => {
+    render(<RightSidebar />)
+
+    fireEvent.click(screen.getByRole("button", { name: "10x" }))
+
+    expect(setTimeScaleMultiplier).toHaveBeenCalledWith(10)
+    expect(screen.getByRole("status")).toHaveTextContent("Simulation speed set to 10x")
   })
 })

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import { useAppState, LEO_LIMITS } from "@/lib/store"
 import { visVivaKmPerSec, calculateLEODecayRate, hohmannDeltaVKmPerSec, KM_PER_UNIT_CONST } from "@/lib/kepler"
 
@@ -34,6 +34,7 @@ export function RightSidebar() {
   const [statusText, setStatusText] = useState("No pending changes.")
   const [satStatusText, setSatStatusText] = useState("Telemetry synchronized.")
   const [boostStatus, setBoostStatus] = useState("")
+  const [speedAnnouncement, setSpeedAnnouncement] = useState("")
 
   // ── Validation ──────────────────────────────────────────────────────────────
   // Each key maps to an error string (non-empty = invalid) or null (valid).
@@ -169,10 +170,13 @@ export function RightSidebar() {
     setTimeout(() => setBoostStatus(""), 3000)
   }
 
+  const handleTimeScaleChange = (multiplier: number) => {
+    setTimeScaleMultiplier(multiplier)
+    setSpeedAnnouncement(`Simulation speed set to ${multiplier}x`)
+  }
+
   // ── LEO health bar: green above 300 km, amber 200-300 km, red below ──
   const altFraction = (satAltitude - LEO_LIMITS.FLOOR) / (LEO_LIMITS.CEILING - LEO_LIMITS.FLOOR)
-  // Add some fake variance for the display
-  const thrustVariation = (Math.sin(Date.now() / 1000) * 0.1).toFixed(2)
   const decayRate = (calculateLEODecayRate(satAltitude) * 60).toFixed(2) // km/min
   const altitudeHealth: "ok" | "warn" | "crit" =
     satAltitude > 300 ? "ok" : satAltitude > 220 ? "warn" : "crit"
@@ -234,6 +238,24 @@ export function RightSidebar() {
             {/* Time Controls */}
             <div className="panel-section">
               <div className="panel-section-title">Time Controls</div>
+              <div
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                style={{
+                  position: "absolute",
+                  width: 1,
+                  height: 1,
+                  padding: 0,
+                  margin: -1,
+                  overflow: "hidden",
+                  clip: "rect(0, 0, 0, 0)",
+                  whiteSpace: "nowrap",
+                  border: 0,
+                }}
+              >
+                {speedAnnouncement}
+              </div>
               <div className="flex gap-2">
                 <button
                   onClick={toggleSimulation}
@@ -254,7 +276,7 @@ export function RightSidebar() {
                   {[1, 2, 5, 10].map((m) => (
                     <button
                       key={m}
-                      onClick={() => setTimeScaleMultiplier(m)}
+                      onClick={() => handleTimeScaleChange(m)}
                       className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
                         timeScaleMultiplier === m ? "bg-indigo-600 text-white" : "text-slate-400 hover:text-white hover:bg-slate-800"
                       }`}
@@ -574,15 +596,15 @@ export const SettingsMicroStore = { theme: 'dark' };
 // Exported hero image priority configuration to prevent layout shift race
 export const HERO_IMG_CONFIG = { priority: true, fetchPriority: 'high' };
 // Onboarding modal isolation boundary
-export const OnboardingBoundary = ({children}: any) => children;
+export const OnboardingBoundary = ({children}: { children: ReactNode }) => children;
 // Extracted generic modal UI shell
-export const ModalShell = ({children}: any) => { return children; };
+export const ModalShell = ({children}: { children: ReactNode }) => { return children; };
 /**
  * User-configurable settings layout props. Manages theme, performance, and accessibility toggles.
  */
 export const SETTINGS_DOCS = true;
 // Settings listener cleanup helper
-export const cleanupSettingsListener = (cb: any) => window.removeEventListener('resize', cb);
+export const cleanupSettingsListener = (cb: EventListenerOrEventListenerObject) => window.removeEventListener('resize', cb);
 // lucide-react import optimization
 export const SettingsIconRef = null;
 // Fixed #199: Added React.useCallback to Settings Modal input handlers.


### PR DESCRIPTION
## Related Issue

Closes #2078

---

## Change Summary

- Added a polite, atomic `role="status"` live region to the Time Controls panel.
- Routed simulation speed button clicks through a handler that keeps current speed behavior and announces the selected multiplier, e.g. `Simulation speed set to 10x`.
- Added regression coverage for the live-region announcement and refreshed the RightSidebar store mock so current controls render correctly.
- Tightened touched-file lint typing in `RightSidebar.tsx` without changing unrelated app behavior.

---

## Suggested Area

Accessibility

---

## Core Files Changed

- `src/components/RightSidebar.tsx`
- `src/__tests__/RightSidebar.test.tsx`

---

## Verification

- Screen-reader-only announcement; no visible layout change.
- `npm test -- --run src/__tests__/RightSidebar.test.tsx` - passed, 3 tests.
- `npm run typecheck` - passed.
- `npx eslint src/components/RightSidebar.tsx src/__tests__/RightSidebar.test.tsx --format json` - passed, clean result for touched files.
- `npm run build` - passed.
- `git diff --check -- src/components/RightSidebar.tsx src/__tests__/RightSidebar.test.tsx` - passed.
- `npm run lint -- --format json` - repo-wide run still reports pre-existing findings outside these touched files; touched files are clean.

---

## AI Assistance Declaration

**Did you use an AI tool to write or assist with this code OR Pull Request?**

- [x] Yes
- [ ] No

- **Which AI Model did you use?**: GPT-5 Codex
- **Which Platform/Tool?**: Codex
- **What exactly did the AI do?**: Assisted with repository inspection, the live-region implementation, test updates, and local verification.
- **What exactly did YOU do?**: Reviewed the assigned task, kept the change scoped, verified account and repository safety, and validated the implementation locally.
- **What is the advantage of using this AI approach here?**: Faster accessibility-focused implementation with explicit regression coverage and verification.

---

## Reviewer Notes

- This is intentionally screen-reader-only; there should be no visible layout change.
- The live region starts empty and announces only after a user chooses a speed multiplier.
- Existing local `docs/ARCHITECTURE.md` changes were not included in this PR.

---

## Local Verification Pledge

- [x] I tested these changes in my own local branch.
- [x] I verified this code compiles into a standalone build and does not break existing production behavior.
